### PR TITLE
More error handling

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,7 +1,7 @@
 # Development
 
-The Qualys integration uses various endpoints within the collection of
-Qualys APIs to ingest data.
+The Qualys integration uses various endpoints within the collection of Qualys
+APIs to ingest data.
 
 ## Provider account setup
 
@@ -19,8 +19,8 @@ app.
 
 ## Configure your .env
 
-By default, a Qualys trial does not allow access to knowledge base so
-a fake Qualys knowledge base is provided as a tool in this integration.
+By default, a Qualys trial does not allow access to knowledge base so a fake
+Qualys knowledge base is provided as a tool in this integration.
 
 Here's the recommended `.env` for this project:
 
@@ -48,8 +48,8 @@ JUPITERONE_API_KEY=
 
 ## Running integration
 
-First, start fake Qualys Knowledge Base server if your license does not
-allow knowledge base requests.
+First, start fake Qualys Knowledge Base server if your license does not allow
+knowledge base requests.
 
 ```sh
 yarn start:fake-knowledge-base-server

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  setupFilesAfterEnv: ['./jest.env.js'],
   clearMocks: true,
   restoreMocks: true,
   preset: 'ts-jest',

--- a/jest.env.js
+++ b/jest.env.js
@@ -1,0 +1,1 @@
+process.env.RUNNING_TESTS = 'true';

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "start:fake-knowledge-base-server": "./tools/bin/run-command fake-knowledge-base"
   },
   "dependencies": {
-    "@jupiterone/integration-sdk": "^1.1.2",
+    "@jupiterone/integration-sdk": "^2.1.0",
     "colors": "^1.4.0",
     "dotenv": "^8.2.0",
     "fast-xml-parser": "^3.16.0",

--- a/src/collectors/collectHostDetections.ts
+++ b/src/collectors/collectHostDetections.ts
@@ -10,7 +10,7 @@ import {
 } from '../converters';
 import QualysClient from '../provider/QualysClient';
 import QualysVulnEntityManager from './QualysVulnEntityManager';
-import { HostEntity } from 'src/converters/types';
+import { HostEntity } from '../converters/types';
 import {
   IntegrationStepExecutionContext,
   Relationship,

--- a/src/collectors/collectVulnerabilities.ts
+++ b/src/collectors/collectVulnerabilities.ts
@@ -1,5 +1,6 @@
 import {
-  IntegrationStepExecutionContext, createIntegrationEntity,
+  IntegrationStepExecutionContext,
+  createIntegrationEntity,
 } from '@jupiterone/integration-sdk';
 import QualysVulnEntityManager from './QualysVulnEntityManager';
 

--- a/src/collectors/collectWebApps.ts
+++ b/src/collectors/collectWebApps.ts
@@ -1,8 +1,9 @@
 import QualysClient from '../provider/QualysClient';
-import pAll, { PromiseFactory } from 'p-all';
 import toArray from '../util/toArray';
 import { IntegrationStepExecutionContext } from '@jupiterone/integration-sdk';
 import { convertWebAppToEntity } from '../converters';
+import { wrapMapFunctionWithInvokeSafely } from '../util/errorHandlerUtil';
+import pMap from 'p-map';
 
 export default async function collectWebApps(
   context: IntegrationStepExecutionContext,
@@ -22,14 +23,15 @@ export default async function collectWebApps(
   });
 
   const webAppScanIdSet = new Set<number>();
-  const webAppWork: PromiseFactory<void>[] = [];
+  // const webAppWork: PromiseFactory<void>[] = [];
+  const webAppIds: number[] = [];
 
   let pageIndex = 0;
 
   do {
     logger.info('Fetching page of web apps...');
 
-    const {responseData} = await paginator.nextPage();
+    const { responseData } = await paginator.nextPage();
 
     const webApps = toArray(responseData.ServiceResponse?.data?.WebApp);
 
@@ -41,35 +43,43 @@ export default async function collectWebApps(
         'Fetched page of web apps',
       );
 
-      await context.jobState.addEntities(
-        webApps.map((webApp) => {
-          webAppWork.push(async () => {
-            const {
-              responseData,
-            } = await qualysClient.webApplicationScanning.fetchWebApp({
-              webAppId: webApp.id!,
-            });
-
-            const lastScanId =
-              responseData.ServiceResponse?.data?.WebApp?.lastScan?.id;
-            if (lastScanId !== undefined) {
-              webAppScanIdSet.add(lastScanId);
-            }
-          });
-
-          return convertWebAppToEntity({ webApp });
-        }),
-      );
+      for (const webApp of webApps) {
+        webAppIds.push(webApp.id!);
+        await context.jobState.addEntity(convertWebAppToEntity({ webApp }));
+      }
     } else if (pageIndex === 0) {
-      logger.info({
-        responseData
-      }, 'No data in listWebApps');
+      logger.info(
+        {
+          responseData,
+        },
+        'No data in listWebApps',
+      );
     }
 
     pageIndex++;
   } while (paginator.hasNextPage());
 
-  await pAll(webAppWork, {
+  const collectWebAppScanIds = wrapMapFunctionWithInvokeSafely(
+    context,
+    {
+      operationName: 'collectWebAppScanIds',
+    },
+    async (webAppId: number) => {
+      const {
+        responseData,
+      } = await qualysClient.webApplicationScanning.fetchWebApp({
+        webAppId: webAppId,
+      });
+
+      const lastScanId =
+        responseData.ServiceResponse?.data?.WebApp?.lastScan?.id;
+      if (lastScanId !== undefined) {
+        webAppScanIdSet.add(lastScanId);
+      }
+    },
+  );
+
+  await pMap(webAppIds, collectWebAppScanIds, {
     concurrency: 5,
   });
 

--- a/src/converters/types.ts
+++ b/src/converters/types.ts
@@ -1,5 +1,5 @@
 import { Entity } from '@jupiterone/integration-sdk';
-import { Ec2AssetSourceSimple } from 'src/provider/assetManagement/types.listHostAssets';
+import { Ec2AssetSourceSimple } from '../provider/assetManagement/types.listHostAssets';
 
 export interface QualysVulnerabilityEntity extends Entity {
   _type: 'qualys_vuln';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,9 @@ import instanceConfigFields from './instanceConfigFields';
 import validateInvocation from './validateInvocation';
 
 import collectData from './steps/collect-data';
+import { QualysIntegrationConfig } from './types';
 
-export const invocationConfig: IntegrationInvocationConfig = {
+export const invocationConfig: IntegrationInvocationConfig<QualysIntegrationConfig> = {
   instanceConfigFields,
   validateInvocation,
   integrationSteps: [collectData],

--- a/src/provider/errors.ts
+++ b/src/provider/errors.ts
@@ -1,4 +1,5 @@
 import { QualysApiRequestResponse } from './QualysClient';
+import { IntegrationError } from '@jupiterone/integration-sdk/src/errors';
 
 const QUALYS_CLIENT_API_ERROR = Symbol('QualysClientApiError');
 
@@ -7,11 +8,9 @@ type QualysClientErrorOptions = {
   message: string;
 };
 
-export class QualysClientError extends Error {
-  code: string;
+export class QualysClientError extends IntegrationError {
   constructor(options: QualysClientErrorOptions) {
-    super(options.message);
-    this.code = options.code;
+    super(options);
   }
 }
 
@@ -32,7 +31,7 @@ export class QualysClientApiError extends QualysClientError {
     const { code, message, requestResponse } = options;
     super({
       code: code,
-      message: `${message} (code=${code}, url: ${requestResponse.request.url}, responseStatus=${requestResponse.response.status})`,
+      message: message,
     });
     this.requestResponse = requestResponse;
   }

--- a/src/provider/knowledgeBase/types.listQualysVulnerabilities.ts
+++ b/src/provider/knowledgeBase/types.listQualysVulnerabilities.ts
@@ -1,13 +1,13 @@
 import { PossibleArray, ISODateString } from '../../types';
 
 export type QualysVulnerabilitiesErrorResponse = {
-  "SIMPLE_RETURN": {
-    "RESPONSE": {
-      "DATETIME": ISODateString,
-      "CODE": number,
-      "TEXT": string;
-    }
-  }
+  SIMPLE_RETURN: {
+    RESPONSE: {
+      DATETIME: ISODateString;
+      CODE: number;
+      TEXT: string;
+    };
+  };
 };
 
 export type ListQualysVulnerabilitiesReply = {

--- a/src/steps/collect-data.test.ts
+++ b/src/steps/collect-data.test.ts
@@ -1,0 +1,124 @@
+import collectHostAssets from '../collectors/collectHostAssets';
+import collectHostDetections from '../collectors/collectHostDetections';
+import collectWebAppScans from '../collectors/collectWebAppScans';
+import collectWebApps from '../collectors/collectWebApps';
+import collectVulnerabilities from '../collectors/collectVulnerabilities';
+
+import collectDataStep from './collect-data';
+import { IntegrationStepExecutionContext } from '@jupiterone/integration-sdk';
+import { createMockStepExecutionContext } from '@jupiterone/integration-sdk/testing';
+import { QualysIntegrationConfig } from '../types';
+import { QualysClientApiError } from '../provider/errors';
+
+jest.mock('../collectors/collectHostAssets', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+jest.mock('../collectors/collectHostDetections', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+jest.mock('../collectors/collectWebAppScans', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+jest.mock('../collectors/collectWebApps', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+jest.mock('../collectors/collectVulnerabilities', () => {
+  return {
+    __esModule: true,
+    default: jest.fn().mockResolvedValue(undefined),
+  };
+});
+
+for (const testInput of [
+  ['collectWebApps', collectWebApps],
+  ['collectWebAppScans', collectWebAppScans],
+  ['collectHostAssets', collectHostAssets],
+  ['collectHostDetections', collectHostDetections],
+  ['collectVulnerabilities', collectVulnerabilities],
+]) {
+  const [operationName, collectFunction] = testInput;
+
+  test(`should publish error event if ${operationName}(...) fails`, async () => {
+    delete process.env.RUNNING_TESTS;
+    const context = createMockStepExecutionContext({
+      instanceConfig: {
+        qualysUsername: 'fake username',
+        qualysPassword: 'fake password',
+        qualysApiUrl: 'fake URL',
+      },
+    }) as IntegrationStepExecutionContext<QualysIntegrationConfig>;
+
+    const qualysApiError = new QualysClientApiError({
+      code: 'fake error code',
+      message: 'fake error message',
+      requestResponse: {
+        request: {
+          url: 'fake url',
+        } as any,
+        responseText: 'fake response text',
+        requestOptions: {} as any,
+        response: {
+          status: 404,
+        } as any,
+        responseData: {} as any,
+      },
+    });
+
+    (collectFunction as jest.Mock).mockRejectedValue(qualysApiError);
+
+    const publishSpy = jest
+      .spyOn(context.logger, 'publishErrorEvent')
+      .mockReturnValue(undefined);
+
+    await collectDataStep.executionHandler(context);
+
+    const expectedAdditionalData = {
+      operationName,
+      responseText: qualysApiError.requestResponse.responseText,
+      responseStatus: qualysApiError.requestResponse.response.status,
+      requestUrl: qualysApiError.requestResponse.request.url,
+    };
+
+    // expect(publishSpy).toHaveBeenCalledTimes(1);
+    expect(publishSpy).toHaveBeenCalledWith({
+      /**
+       * A name to associate with error
+       */
+      name: 'operation_error',
+
+      message: 'Qualys API error occurred',
+
+      /**
+       * The raw error that occurred
+       */
+      err: qualysApiError,
+
+      /**
+       * Any additional data that will only be logged (not published with event)
+       */
+      logData: expectedAdditionalData,
+
+      /**
+       * Contents of `eventData` will be serialized and added to the description
+       * property of the event but it will not be logged.
+       */
+      eventData: expectedAdditionalData,
+    });
+  });
+}

--- a/src/util/errorHandlerUtil.test.ts
+++ b/src/util/errorHandlerUtil.test.ts
@@ -1,0 +1,237 @@
+import {
+  wrapMapFunctionWithInvokeSafely,
+  wrapFunctionWithInvokeSafely,
+  invokeSafely,
+} from './errorHandlerUtil';
+import { createMockStepExecutionContext } from '@jupiterone/integration-sdk/testing';
+
+describe('error events should be published', () => {
+  test('wrapMapFunctionWithInvokeSafely() should return undefined if error is thrown but publish error event', async () => {
+    delete process.env.RUNNING_TESTS;
+    const context = createMockStepExecutionContext({
+      instanceConfig: {
+        qualysUsername: 'fake username',
+        qualysPassword: 'fake password',
+        qualysApiUrl: 'fake URL',
+      },
+    });
+
+    const fakeError = new Error('fake error');
+    const operationFunc = jest.fn().mockRejectedValue(fakeError);
+
+    const publishSpy = jest
+      .spyOn(context.logger, 'publishErrorEvent')
+      .mockReturnValue(undefined);
+
+    const wrappedFunction = await wrapMapFunctionWithInvokeSafely(
+      context,
+      {
+        operationName: 'dummy',
+      },
+      operationFunc,
+    );
+
+    const result = await wrappedFunction({});
+
+    expect(result).toBe(undefined);
+    expect(publishSpy).toHaveBeenCalledTimes(1);
+    expect(publishSpy).toHaveBeenCalledWith({
+      name: 'operation_error',
+      message: 'Unexpected error occurred',
+      err: fakeError,
+      logData: {
+        operationName: 'dummy',
+      },
+
+      /**
+       * Contents of `eventData` will be serialized and added to the description
+       * property of the event but it will not be logged.
+       */
+      eventData: {
+        operationName: 'dummy',
+      },
+    });
+  });
+
+  test('wrapFunctionWithInvokeSafely() should return undefined if error is thrown but publish error event', async () => {
+    delete process.env.RUNNING_TESTS;
+    const context = createMockStepExecutionContext({
+      instanceConfig: {
+        qualysUsername: 'fake username',
+        qualysPassword: 'fake password',
+        qualysApiUrl: 'fake URL',
+      },
+    });
+
+    const fakeError = new Error('fake error');
+    const operationFunc = jest.fn().mockRejectedValue(fakeError);
+
+    const publishSpy = jest
+      .spyOn(context.logger, 'publishErrorEvent')
+      .mockReturnValue(undefined);
+
+    const wrappedFunction = await wrapFunctionWithInvokeSafely(
+      context,
+      {
+        operationName: 'dummy',
+      },
+      operationFunc,
+    );
+
+    const result = await wrappedFunction();
+
+    expect(result).toBe(undefined);
+    expect(publishSpy).toHaveBeenCalledTimes(1);
+    expect(publishSpy).toHaveBeenCalledWith({
+      name: 'operation_error',
+      message: 'Unexpected error occurred',
+      err: fakeError,
+      logData: {
+        operationName: 'dummy',
+      },
+
+      /**
+       * Contents of `eventData` will be serialized and added to the description
+       * property of the event but it will not be logged.
+       */
+      eventData: {
+        operationName: 'dummy',
+      },
+    });
+  });
+
+  test('invokeSafely() should return undefined if error is thrown but publish error event', async () => {
+    delete process.env.RUNNING_TESTS;
+    const context = createMockStepExecutionContext({
+      instanceConfig: {
+        qualysUsername: 'fake username',
+        qualysPassword: 'fake password',
+        qualysApiUrl: 'fake URL',
+      },
+    });
+
+    const fakeError = new Error('fake error');
+    const operationFunc = jest.fn().mockRejectedValue(fakeError);
+
+    const publishSpy = jest
+      .spyOn(context.logger, 'publishErrorEvent')
+      .mockReturnValue(undefined);
+
+    const result = await invokeSafely(
+      context,
+      {
+        operationName: 'dummy',
+      },
+      operationFunc,
+    );
+
+    expect(result).toBe(undefined);
+    expect(publishSpy).toHaveBeenCalledTimes(1);
+    expect(publishSpy).toHaveBeenCalledWith({
+      name: 'operation_error',
+      message: 'Unexpected error occurred',
+      err: fakeError,
+      logData: {
+        operationName: 'dummy',
+      },
+
+      /**
+       * Contents of `eventData` will be serialized and added to the description
+       * property of the event but it will not be logged.
+       */
+      eventData: {
+        operationName: 'dummy',
+      },
+    });
+  });
+});
+
+describe('should not publish error event if no error is thrown', () => {
+  test('wrapMapFunctionWithInvokeSafely() should return value of wrapped function call', async () => {
+    delete process.env.RUNNING_TESTS;
+    const context = createMockStepExecutionContext({
+      instanceConfig: {
+        qualysUsername: 'fake username',
+        qualysPassword: 'fake password',
+        qualysApiUrl: 'fake URL',
+      },
+    });
+
+    const operationFunc = jest.fn().mockResolvedValue('abc');
+
+    const publishSpy = jest
+      .spyOn(context.logger, 'publishErrorEvent')
+      .mockReturnValue(undefined);
+
+    const wrappedFunction = await wrapMapFunctionWithInvokeSafely(
+      context,
+      {
+        operationName: 'dummy',
+      },
+      operationFunc,
+    );
+
+    const result = await wrappedFunction({});
+
+    expect(result).toBe('abc');
+    expect(publishSpy).toHaveBeenCalledTimes(0);
+  });
+
+  test('wrapFunctionWithInvokeSafely() should return value of wrapped function call', async () => {
+    delete process.env.RUNNING_TESTS;
+    const context = createMockStepExecutionContext({
+      instanceConfig: {
+        qualysUsername: 'fake username',
+        qualysPassword: 'fake password',
+        qualysApiUrl: 'fake URL',
+      },
+    });
+
+    const operationFunc = jest.fn().mockResolvedValue('abc');
+
+    const publishSpy = jest
+      .spyOn(context.logger, 'publishErrorEvent')
+      .mockReturnValue(undefined);
+
+    const wrappedFunction = await wrapFunctionWithInvokeSafely(
+      context,
+      {
+        operationName: 'dummy',
+      },
+      operationFunc,
+    );
+
+    const result = await wrappedFunction();
+
+    expect(result).toBe('abc');
+    expect(publishSpy).toHaveBeenCalledTimes(0);
+  });
+
+  test('invokeSafely() should return value of wrapped function call', async () => {
+    delete process.env.RUNNING_TESTS;
+    const context = createMockStepExecutionContext({
+      instanceConfig: {
+        qualysUsername: 'fake username',
+        qualysPassword: 'fake password',
+        qualysApiUrl: 'fake URL',
+      },
+    });
+
+    const operationFunc = jest.fn().mockResolvedValue('abc');
+
+    const publishSpy = jest
+      .spyOn(context.logger, 'publishErrorEvent')
+      .mockReturnValue(undefined);
+
+    const result = await invokeSafely(
+      context,
+      {
+        operationName: 'dummy',
+      },
+      operationFunc,
+    );
+
+    expect(result).toBe('abc');
+    expect(publishSpy).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/util/errorHandlerUtil.ts
+++ b/src/util/errorHandlerUtil.ts
@@ -1,0 +1,108 @@
+import { IntegrationStepExecutionContext } from '@jupiterone/integration-sdk';
+import { toPossibleQualysClientApiError } from '../provider/errors';
+
+export type ErrorLogData = {
+  operationName: string;
+  [k: string]: any;
+};
+function handleError(
+  context: IntegrationStepExecutionContext,
+  options: {
+    err: Error;
+    logData: ErrorLogData;
+  },
+) {
+  const { err, logData } = options;
+  const additionalData: Record<string, any> = {
+    ...logData,
+  };
+
+  const qualysApiError = toPossibleQualysClientApiError(err);
+  if (qualysApiError) {
+    additionalData.responseText = qualysApiError.requestResponse.responseText;
+    additionalData.responseStatus =
+      qualysApiError.requestResponse.response.status;
+    additionalData.requestUrl = qualysApiError.requestResponse.request.url;
+  }
+
+  context.logger.publishErrorEvent({
+    name: 'operation_error',
+    message: qualysApiError
+      ? 'Qualys API error occurred'
+      : 'Unexpected error occurred',
+    err,
+
+    // Log the additional data
+    logData: additionalData,
+
+    // Include additional data in error event that is published
+    eventData: additionalData,
+  });
+
+  if (process.env.RUNNING_TESTS) {
+    throw err;
+  }
+}
+
+export function wrapMapFunctionWithInvokeSafely<I, O>(
+  context: IntegrationStepExecutionContext,
+  options: {
+    operationName: string;
+  },
+  func: (input: I) => Promise<O>,
+) {
+  return async function (input: I): Promise<O | undefined> {
+    try {
+      return await func(input);
+    } catch (err) {
+      handleError(context, {
+        err,
+        logData: {
+          operationName: options.operationName,
+        },
+      });
+      return undefined;
+    }
+  };
+}
+
+export function wrapFunctionWithInvokeSafely<I, O>(
+  context: IntegrationStepExecutionContext,
+  options: {
+    operationName: string;
+  },
+  func: () => Promise<O>,
+) {
+  return async function (): Promise<O | undefined> {
+    try {
+      return await func();
+    } catch (err) {
+      handleError(context, {
+        err,
+        logData: {
+          operationName: options.operationName,
+        },
+      });
+      return undefined;
+    }
+  };
+}
+
+export async function invokeSafely<O>(
+  context: IntegrationStepExecutionContext,
+  options: {
+    operationName: string;
+  },
+  func: () => Promise<O>,
+): Promise<O | undefined> {
+  try {
+    return await func();
+  } catch (err) {
+    handleError(context, {
+      err,
+      logData: {
+        operationName: options.operationName,
+      },
+    });
+  }
+}

--- a/src/validateInvocation.ts
+++ b/src/validateInvocation.ts
@@ -1,5 +1,6 @@
 import { IntegrationExecutionContext } from '@jupiterone/integration-sdk';
 import { URL } from 'url';
+import { QualysIntegrationConfig } from './types';
 
 const REQUIRED_PROPERTIES = [
   'qualysUsername',
@@ -8,7 +9,7 @@ const REQUIRED_PROPERTIES = [
 ];
 
 export default async function validateInvocation(
-  context: IntegrationExecutionContext,
+  context: IntegrationExecutionContext<QualysIntegrationConfig>,
 ) {
   context.logger.info(
     {

--- a/test/collect-data.test.ts
+++ b/test/collect-data.test.ts
@@ -11,6 +11,8 @@ import {
   TYPE_QUALYS_HOST_FINDING,
   TYPE_QUALYS_VULN,
 } from '../src/converters';
+import { IntegrationStepExecutionContext } from '@jupiterone/integration-sdk';
+import { QualysIntegrationConfig } from '../src/types';
 
 jest.setTimeout(60000);
 
@@ -54,7 +56,7 @@ test('should be able to collect all data', async () => {
     instanceConfig: {
       qualysApiUrl: 'https://BLAH.qg3.apps.qualys.com',
     },
-  });
+  }) as IntegrationStepExecutionContext<QualysIntegrationConfig>;
 
   await collectDataStep.executionHandler(context);
 

--- a/tools/commands/fake-knowledge-base/index.ts
+++ b/tools/commands/fake-knowledge-base/index.ts
@@ -228,21 +228,24 @@ type RequestHandlerInput = {
 
 type RequestHandlerOutput = {
   body: string;
-}
+};
 
-type RequestHandler = (input: RequestHandlerInput) => Promise<RequestHandlerOutput>;
-
+type RequestHandler = (
+  input: RequestHandlerInput,
+) => Promise<RequestHandlerOutput>;
 
 const ROUTES: Record<string, RequestHandler> = {
   '/api/2.0/fo/knowledge_base/vuln': async function (input) {
-    const {req, res, url} = input;
+    const { req, res, url } = input;
     res.setHeader('content-type', 'text/xml');
     console.log('REQUEST URL: ' + req.url);
 
     const ids = url.searchParams.get('ids');
     const qidList = ids ? ids.split(',') : [];
 
-    console.log('Responding with fake response for following QIDs: ' + qidList.join(', '));
+    console.log(
+      'Responding with fake response for following QIDs: ' + qidList.join(', '),
+    );
 
     const body = `
   <KNOWLEDGE_BASE_VULN_LIST_OUTPUT>
@@ -252,19 +255,23 @@ const ROUTES: Record<string, RequestHandler> = {
       </VULN_LIST>
     </RESPONSE>
   </KNOWLEDGE_BASE_VULN_LIST_OUTPUT>`;
-    return {body};
-  }
-}
+    return { body };
+  },
+};
 
-async function handleRequest(req: IncomingMessage, res: ServerResponse, serverConfig: {
-  host: string;
-}): Promise<RequestHandlerOutput> {
+async function handleRequest(
+  req: IncomingMessage,
+  res: ServerResponse,
+  serverConfig: {
+    host: string;
+  },
+): Promise<RequestHandlerOutput> {
   const url = new URL(req.url!, serverConfig.host);
   const handler = ROUTES[url.pathname];
   if (!handler) {
     res.statusCode = 404;
     return {
-      body: 'Not found'
+      body: 'Not found',
     };
   }
 
@@ -272,7 +279,7 @@ async function handleRequest(req: IncomingMessage, res: ServerResponse, serverCo
     req,
     res,
     url,
-    serverConfig
+    serverConfig,
   });
 }
 
@@ -284,19 +291,21 @@ function handleRequestError(err: Error, res: ServerResponse) {
 
 async function startServer(options: RunOptions) {
   const serverConfig = {
-    host: `http://localhost:${options.port}`
+    host: `http://localhost:${options.port}`,
   };
 
   return new Promise<StartOutput>((resolve, reject) => {
     const server = http.createServer(
       (req: IncomingMessage, res: ServerResponse) => {
         try {
-          handleRequest(req, res, serverConfig).then((output) => {
-            res.write(output.body);
-            res.end();
-          }).catch(err => {
-            handleRequestError(err, res);
-          })
+          handleRequest(req, res, serverConfig)
+            .then((output) => {
+              res.write(output.body);
+              res.end();
+            })
+            .catch((err) => {
+              handleRequestError(err, res);
+            });
         } catch (err) {
           handleRequestError(err, res);
         }
@@ -304,7 +313,7 @@ async function startServer(options: RunOptions) {
     );
 
     server.on('error', (err) => {
-      console.log('Error!')
+      console.log('Error!');
       reject(err);
     });
 
@@ -319,11 +328,11 @@ async function startServer(options: RunOptions) {
   });
 }
 
-
-
 export async function run() {
-  const port = process.env.FAKE_QUALYS_KNOWLEDGE_BASE_SERVER_PORT ? parseInt(process.env.FAKE_QUALYS_KNOWLEDGE_BASE_SERVER_PORT, 10) : 8080;
+  const port = process.env.FAKE_QUALYS_KNOWLEDGE_BASE_SERVER_PORT
+    ? parseInt(process.env.FAKE_QUALYS_KNOWLEDGE_BASE_SERVER_PORT, 10)
+    : 8080;
   await startServer({
     port,
-  })
+  });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -443,24 +443,25 @@
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
 
-"@jupiterone/data-model@^0.3.1":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@jupiterone/data-model/-/data-model-0.3.1.tgz#81533c2e073c0f6a137b328d7d568b1f1437dff9"
-  integrity sha512-fryUlbB5q08YdtkoQ+Vw8EmTLRDMYCw/nE9J9QcGj+vko7zau7qDzZZtqKU7XsBrl+eThdIaCAdsQv8fMA9Hzw==
+"@jupiterone/data-model@^0.4.1":
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/data-model/-/data-model-0.4.1.tgz#75405273c07eaab1892ef2a829f5894c6bf5b5a7"
+  integrity sha512-Z5NalEL9yQQ3wdQ0BLzo2rXvvxyURKZmw2V8kVX8UjKExwXBStgoArEIZEklN3l/r3PjjviPJk51V+J9K8+Q4w==
   dependencies:
     ajv "^6.12.0"
 
-"@jupiterone/integration-sdk@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk/-/integration-sdk-1.1.2.tgz#21606ce7581342e1f333bc583af8d055133accf1"
-  integrity sha512-jydy9HsCqWXclBMJqgJjB/WSn/nbuvikwucJTdYW8faUlJR4prX6x/WYIIPLfiWfztVny+apH+edHwA5mxUxeA==
+"@jupiterone/integration-sdk@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk/-/integration-sdk-2.1.0.tgz#f77d04d275e11a55f52a878766aca27ac4d3f82d"
+  integrity sha512-2bpYFO6YnpaYmtIqUZNHj309FpIiOHzMm13RUZ+MbPhhVfhCc3k+hoc4bOj65OwubhAi5CYpZdj6gOl9v7UpdA==
   dependencies:
-    "@jupiterone/data-model" "^0.3.1"
+    "@jupiterone/data-model" "^0.4.1"
     "@lifeomic/alpha" "^1.1.3"
     "@pollyjs/adapter-node-http" "^4.0.4"
     "@pollyjs/core" "^4.0.4"
     "@pollyjs/persister-fs" "^4.0.4"
     "@types/bunyan" "^1.8.6"
+    "@types/har-format" "^1.2.4"
     "@types/pollyjs__adapter-node-http" "^2.0.0"
     "@types/pollyjs__core" "^4.0.0"
     "@types/pollyjs__persister" "^2.0.1"
@@ -663,6 +664,11 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#1ee30d79544ca84d68d4b3cdb0af4f205663dd2d"
   integrity sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==
+
+"@types/har-format@^1.2.4":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@types/har-format/-/har-format-1.2.4.tgz#3275842095abb60d14b47fa798cc9ff708dab6d4"
+  integrity sha512-iUxzm1meBm3stxUMzRqgOVHjj4Kgpgu5w9fm4X7kPRfSgVRzythsucEN7/jtOo8SQzm+HfcxWWzJS0mJDH/3DQ==
 
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.1"


### PR DESCRIPTION
This change uses the new `logger.publishErrorEvent(...)` function and it also wraps all operations with helper function for handling/logging errors instead of throwing. This will allow the integration to proceed even if Qualys API returns 404.

**NOTE:** This would haven not been entirely necessary if I was making better use of _steps_ but I had the problem of needing to share data between steps which wasn't available when I originally created this integration.