### PR TITLE
Retry failed connections, limit concurrency on scan requests to 1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "start:fake-knowledge-base-server": "./tools/bin/run-command fake-knowledge-base"
   },
   "dependencies": {
+    "@lifeomic/attempt": "^3.0.0",
     "colors": "^1.4.0",
     "dotenv": "^8.2.0",
     "fast-xml-parser": "^3.16.0",

--- a/src/collectors/collectWebApps.ts
+++ b/src/collectors/collectWebApps.ts
@@ -82,7 +82,7 @@ export default async function collectWebApps(
   );
 
   await pMap(webAppIds, collectWebAppScanIds, {
-    concurrency: 5,
+    concurrency: 1,
   });
 
   logger.info('Finished collecting web apps');

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,6 +627,11 @@
     resolve-pathname "^3.0.0"
     url-parse "^1.4.7"
 
+"@lifeomic/attempt@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@lifeomic/attempt/-/attempt-3.0.0.tgz#75fecc204f8b0ac18b5363b4404bb32450f01859"
+  integrity sha512-Ibk4Vfl46dSrhtH5fHsrTA4waAuyP7/qcr3uo0mO70azRc6LWgJILlMy3B1oOvyiN9jQcdqwsThaQkPKLiYKTg==
+
 "@nodelib/fs.scandir@2.1.3":
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz#3a582bdb53804c6ba6d146579c46e52130cf4a3b"


### PR DESCRIPTION
I noted that https://pypi.org/project/qualysapi/ retries connection timeouts up to 10 times, so I thought that might be worthwhile for us to do as well. I'd like to find out from Qualys what is going on; are they rate limiting by refusing connections for some period of time?