### PR TITLE
Release 3.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-qualys",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Qualys integration for JupiterOne",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/collectors/collectWebApps.ts
+++ b/src/collectors/collectWebApps.ts
@@ -82,7 +82,7 @@ export default async function collectWebApps(
   );
 
   await pMap(webAppIds, collectWebAppScanIds, {
-    concurrency: 1,
+    concurrency: 3,
   });
 
   logger.info('Finished collecting web apps');

--- a/src/provider/QualysClient.ts
+++ b/src/provider/QualysClient.ts
@@ -222,7 +222,7 @@ export default class QualysClient {
       method: requestOptions.method,
       headers,
       body: requestOptions.body,
-      timeout: 1000 * 30,
+      timeout: 1000 * 60,
     });
 
     const response = await retry(async () => await fetch(request), {


### PR DESCRIPTION
After further analysis in the light of daytime, it seems that the error is more of a time waiting for a response problem, not a connection timeout. This means we should allow more time for them to generate a response, and it means we need to allow more than one request at a time or we'll have a series of minutes waiting.