### PR TITLE
Add logging and safety check of `lastId`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ### Changed
 
+- Added logging
+- Checked for no `lastId` in determining whether there is another page
+
+## ??
+
+### Changed
+
 - Fix a bunch of lint warnings and errors
 
 ## 1.2.1 2020-05-20

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-qualys",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "Qualys integration for JupiterOne",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/collectors/QualysVulnEntityManager.ts
+++ b/src/collectors/QualysVulnEntityManager.ts
@@ -47,6 +47,8 @@ export default class QualysVulnEntityManager {
           },
         );
 
+        let pageIndex = 0;
+
         do {
           const { responseData } = await qualysVulnPaginator.nextPage();
 
@@ -77,6 +79,14 @@ export default class QualysVulnEntityManager {
               ?.VULN,
           );
 
+          logger.info(
+            {
+              numVulns: vulnList.length,
+              pageIndex,
+            },
+            'Fetched page of vulnerabilities',
+          );
+
           const entities: QualysVulnerabilityEntity[] = [];
 
           for (const vuln of vulnList) {
@@ -88,6 +98,8 @@ export default class QualysVulnEntityManager {
 
             entities.push(entity);
           }
+
+          pageIndex++;
         } while (qualysVulnPaginator.hasNextPage());
 
         logger.info('Finished fetching vulnerabilities from knowledge base');

--- a/src/collectors/collectHostAssets.ts
+++ b/src/collectors/collectHostAssets.ts
@@ -24,10 +24,19 @@ export default async function collectHostAssets(
   let pageIndex = 0;
 
   do {
+    logger.info('Fetching page of host assets...');
+
     const { responseData } = await hostAssetsPaginator.nextPage();
     const hostAssets = toArray(responseData?.ServiceResponse?.data?.HostAsset);
     const hostEntities: HostEntity[] = [];
     if (hostAssets.length) {
+      logger.info(
+        {
+          numHostAssets: hostAssets.length,
+          pageIndex,
+        },
+        'Fetched page of host assets',
+      );
       for (const hostAsset of hostAssets) {
         const qwebHostId = hostAsset.qwebHostId;
         if (qwebHostId) {

--- a/src/collectors/collectHostDetections.ts
+++ b/src/collectors/collectHostDetections.ts
@@ -48,12 +48,22 @@ export default async function collectHostDetections(
   const seenFindingEntityKeys = new Set<string>();
 
   do {
+    logger.info('Fetching page of host detections...');
+
     const { responseData } = await hostDetectionsPaginator.nextPage();
     const hosts = toArray(
       responseData.HOST_LIST_VM_DETECTION_OUTPUT?.RESPONSE?.HOST_LIST?.HOST,
     );
 
     if (hosts.length) {
+      logger.info(
+        {
+          numHostDetections: hosts.length,
+          pageIndex,
+        },
+        'Fetched page of host detections',
+      );
+
       for (const host of hosts) {
         const hostId = host.ID!;
         let hostEntity: HostEntity = hostEntityLookup[hostId];

--- a/src/collectors/collectWebAppScans.ts
+++ b/src/collectors/collectWebAppScans.ts
@@ -107,6 +107,7 @@ export default async function collectWebAppScans(
         logger.info(
           {
             responseData,
+            webAppScanId,
           },
           'No data in fetchScanResults',
         );

--- a/src/collectors/collectWebApps.ts
+++ b/src/collectors/collectWebApps.ts
@@ -41,6 +41,7 @@ export default async function collectWebApps(
       logger.info(
         {
           numWebApps: webApps.length,
+          pageIndex,
         },
         'Fetched page of web apps',
       );

--- a/src/provider/paginationUtil.ts
+++ b/src/provider/paginationUtil.ts
@@ -55,7 +55,7 @@ export function buildRestApiNextPageRequest(options: {
   const responseData: any = result.responseData;
   const hasMoreRecords = responseData.ServiceResponse?.hasMoreRecords;
   const lastId = responseData.ServiceResponse?.lastId;
-  return hasMoreRecords
+  return lastId && hasMoreRecords
     ? {
         ...requestOptions,
         body: buildRestApiPaginatedRequestBody({


### PR DESCRIPTION
The `collectHostAssets` step appears to have gone into an infinite loop, and there was not logging to know for sure whether things were advancing.

The `lastId` of the response could be `undefined`. @philidem suggested checking that in case there are circumstances where they answer there are more pages but give us no `lastId`.