### PR TITLE
Increase per page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 4.1.2 2020-10-11
+
 ### Changed
 
 - `iterateScannedHostIds` defaults to requesting 5000 IDs per page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Changed
+
+- `iterateScannedHostIds` defaults to requesting 5000 IDs per page
+- `iterateHostDetails` now supports `options?: { pageSize }` and defaults to
+  requesting details for 1000 hosts per page
+- `iterateHostDetections` now supports `options?: { pageSize }` and defaults to
+  requesting detections for 1000 hosts per page
+- `iterateVulnerabilities` now supports `options?: { pageSize }` and defaults to
+  requesting 1000 vulnerabilities per page
+
 ## 4.1.1 2020-10-10
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-qualys",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "description": "Qualys integration for JupiterOne",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/provider/__tests__/client.test.ts
+++ b/src/provider/__tests__/client.test.ts
@@ -927,6 +927,9 @@ describe('iterateHostDetections', () => {
       ({ host, detections }) => {
         hosts.push(host);
       },
+      {
+        pageSize: 300,
+      },
     );
 
     expect(hosts.length).toBe(2);

--- a/src/steps/__tests__/__recordings__/steps_741716276/recording.har
+++ b/src/steps/__tests__/__recordings__/steps_741716276/recording.har
@@ -514,7 +514,7 @@
         }
       },
       {
-        "_id": "4b608d6a45257e7713f4e11b3f3f6209",
+        "_id": "8e0797617e461cd38713a5bd0ada986a",
         "_order": 0,
         "cache": {},
         "request": {
@@ -570,10 +570,10 @@
             },
             {
               "name": "truncation_limit",
-              "value": "300"
+              "value": "5000"
             }
           ],
-          "url": "https://qualysapi.qg3.apps.qualys.com/api/2.0/fo/asset/host/?action=list&details=None&truncation_limit=300"
+          "url": "https://qualysapi.qg3.apps.qualys.com/api/2.0/fo/asset/host/?action=list&details=None&truncation_limit=5000"
         },
         "response": {
           "bodySize": 736,

--- a/src/steps/vmdr/index.ts
+++ b/src/steps/vmdr/index.ts
@@ -48,16 +48,13 @@ export async function fetchScannedHostIds({
   const loggerFetch = logger.child({ filter: 'all' });
 
   const hostIds: QWebHostId[] = [];
-  await apiClient.iterateScannedHostIds(
-    (pageOfIds) => {
-      pageOfIds.forEach((e) => hostIds.push(e));
-      loggerFetch.info(
-        { numScannedHostIds: hostIds.length },
-        'Fetched page of scanned host IDs',
-      );
-    },
-    { pageSize: 300 },
-  );
+  await apiClient.iterateScannedHostIds((pageOfIds) => {
+    pageOfIds.forEach((e) => hostIds.push(e));
+    loggerFetch.info(
+      { numScannedHostIds: hostIds.length },
+      'Fetched page of scanned host IDs',
+    );
+  });
 
   await jobState.setData(DATA_SCANNED_HOST_IDS, hostIds);
 


### PR DESCRIPTION
A customer's scanned host IDs exceeded 700K, which took took ~2,300 requests at 300/page. I terminated the process because the remaining work of fetching host details and then detections and vulnerabilities, with their 100 or 300 per page settings was going to consume too much of their 10,000 request/12 hours limit.

The default page size for host/vulnerability data is now 1000, except the host id fetching which is 5000 since it is only getting ID data back. We may find that we really should go much higher even on these endpoints.