### PR TITLE
Avoid step failures when no hosts, details found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid `fetchScannedHostDetails` step failure when no hosts found
+- Avoid `fetchScannedHostFindings` step failure when no hosts found, or when
+  details could not be loaded for hosts
+
 ## 4.3.0 2020-10-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 4.3.1 2020-10-20
+
 ### Fixed
 
 - Avoid `fetchScannedHostDetails` step failure when no hosts found

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-qualys",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "Qualys integration for JupiterOne",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/steps/__tests__/__recordings__/fetchScannedHostDetails_223744471/recording.har
+++ b/src/steps/__tests__/__recordings__/fetchScannedHostDetails_223744471/recording.har
@@ -1,0 +1,256 @@
+{
+  "log": {
+    "_recordingName": "fetchScannedHostDetails",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "5cb93e99a45d412ac29b8aae666fd8f7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-requested-with",
+              "value": "@jupiterone/graph-qualys"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "qualysapi.qg3.apps.qualys.com"
+            }
+          ],
+          "headersSize": 345,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://qualysapi.qg3.apps.qualys.com/qps/rest/portal/version"
+        },
+        "response": {
+          "bodySize": 1343,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 1343,
+            "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ServiceResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"https://qualysapi.qg3.apps.qualys.com/qps/xsd/version.xsd\">\n  <responseCode>SUCCESS</responseCode>\n  <count>1</count>\n  <data>\n    <Portal-Version>\n      <PortalApplication-VERSION>3.1.2.0-2 OFFICIAL #597 (2020-09-15T15:54:59Z)</PortalApplication-VERSION>\n      <ITAM-VERSION>1.2.1.1-1</ITAM-VERSION>\n      <CS-VERSION>1.6.8.2-23</CS-VERSION>\n      <CA-VERSION>2.23.0.0</CA-VERSION>\n      <QGS-VERSION>1.2.0.0-6</QGS-VERSION>\n      <QUESTIONNAIRE-VERSION>2.23.1.0</QUESTIONNAIRE-VERSION>\n      <WAF-VERSION>2.12.4.0</WAF-VERSION>\n      <QUESTIONNAIRE__V2-VERSION>1.10.1.0</QUESTIONNAIRE__V2-VERSION>\n      <WAS-VERSION>6.13.1.0</WAS-VERSION>\n      <FIM-VERSION>2.3.1.0</FIM-VERSION>\n      <VM-VERSION>1.0.3</VM-VERSION>\n      <CERTVIEW-VERSION>2.7.0.0-67</CERTVIEW-VERSION>\n      <CLOUDVIEW-VERSION>1.11.0.0-1</CLOUDVIEW-VERSION>\n      <CM-VERSION>1.30.0.0</CM-VERSION>\n      <MDS-VERSION>2.15.7.0</MDS-VERSION>\n      <PM-VERSION>1.4.3.0-289</PM-VERSION>\n      <PS-VERSION>1.2.1.0-4</PS-VERSION>\n      <IOC-VERSION>3.0.0.0-5</IOC-VERSION>\n      <THREAT__PROTECT-VERSION>1.2.0.0</THREAT__PROTECT-VERSION>\n      <AV2-VERSION>0.1.0</AV2-VERSION>\n      <UD-VERSION>0.0.6</UD-VERSION>\n    </Portal-Version>\n    <QWeb-Version>\n      <WEB-VERSION>10.3.0.3-2</WEB-VERSION>\n      <SCANNER-VERSION>12.1.67-1</SCANNER-VERSION>\n      <VULNSIGS-VERSION>2.5.13-2</VULNSIGS-VERSION>\n    </QWeb-Version>\n  </data>\n</ServiceResponse>"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "JSESSIONID",
+              "path": "/qps",
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 20 Oct 2020 17:18:11 GMT"
+            },
+            {
+              "name": "server",
+              "value": "Apache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1;mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            }
+          ],
+          "headersSize": 378,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-10-20T17:18:08.102Z",
+        "time": 4137,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 4137
+        }
+      },
+      {
+        "_id": "5cb93e99a45d412ac29b8aae666fd8f7",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-requested-with",
+              "value": "@jupiterone/graph-qualys"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "qualysapi.qg3.apps.qualys.com"
+            }
+          ],
+          "headersSize": 345,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://qualysapi.qg3.apps.qualys.com/qps/rest/portal/version"
+        },
+        "response": {
+          "bodySize": 1343,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 1343,
+            "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ServiceResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"https://qualysapi.qg3.apps.qualys.com/qps/xsd/version.xsd\">\n  <responseCode>SUCCESS</responseCode>\n  <count>1</count>\n  <data>\n    <Portal-Version>\n      <PortalApplication-VERSION>3.1.2.0-2 OFFICIAL #597 (2020-09-15T15:54:59Z)</PortalApplication-VERSION>\n      <ITAM-VERSION>1.2.1.1-1</ITAM-VERSION>\n      <CS-VERSION>1.6.8.2-23</CS-VERSION>\n      <CA-VERSION>2.23.0.0</CA-VERSION>\n      <QGS-VERSION>1.2.0.0-6</QGS-VERSION>\n      <QUESTIONNAIRE-VERSION>2.23.1.0</QUESTIONNAIRE-VERSION>\n      <WAF-VERSION>2.12.4.0</WAF-VERSION>\n      <QUESTIONNAIRE__V2-VERSION>1.10.1.0</QUESTIONNAIRE__V2-VERSION>\n      <WAS-VERSION>6.13.1.0</WAS-VERSION>\n      <FIM-VERSION>2.3.1.0</FIM-VERSION>\n      <VM-VERSION>1.0.3</VM-VERSION>\n      <CERTVIEW-VERSION>2.7.0.0-67</CERTVIEW-VERSION>\n      <CLOUDVIEW-VERSION>1.11.0.0-1</CLOUDVIEW-VERSION>\n      <CM-VERSION>1.30.0.0</CM-VERSION>\n      <MDS-VERSION>2.15.7.0</MDS-VERSION>\n      <PM-VERSION>1.4.3.0-289</PM-VERSION>\n      <PS-VERSION>1.2.1.0-4</PS-VERSION>\n      <IOC-VERSION>3.0.0.0-5</IOC-VERSION>\n      <THREAT__PROTECT-VERSION>1.2.0.0</THREAT__PROTECT-VERSION>\n      <AV2-VERSION>0.1.0</AV2-VERSION>\n      <UD-VERSION>0.0.6</UD-VERSION>\n    </Portal-Version>\n    <QWeb-Version>\n      <WEB-VERSION>10.3.0.3-2</WEB-VERSION>\n      <SCANNER-VERSION>12.1.67-1</SCANNER-VERSION>\n      <VULNSIGS-VERSION>2.5.13-2</VULNSIGS-VERSION>\n    </QWeb-Version>\n  </data>\n</ServiceResponse>"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "JSESSIONID",
+              "path": "/qps",
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 20 Oct 2020 17:18:14 GMT"
+            },
+            {
+              "name": "server",
+              "value": "Apache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1;mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            }
+          ],
+          "headersSize": 378,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-10-20T17:18:12.254Z",
+        "time": 2027,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 2027
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/__tests__/__recordings__/fetchScannedHostFindings_4247000165/recording.har
+++ b/src/steps/__tests__/__recordings__/fetchScannedHostFindings_4247000165/recording.har
@@ -1,0 +1,256 @@
+{
+  "log": {
+    "_recordingName": "fetchScannedHostFindings",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "5cb93e99a45d412ac29b8aae666fd8f7",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-requested-with",
+              "value": "@jupiterone/graph-qualys"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "qualysapi.qg3.apps.qualys.com"
+            }
+          ],
+          "headersSize": 345,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://qualysapi.qg3.apps.qualys.com/qps/rest/portal/version"
+        },
+        "response": {
+          "bodySize": 1343,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 1343,
+            "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ServiceResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"https://qualysapi.qg3.apps.qualys.com/qps/xsd/version.xsd\">\n  <responseCode>SUCCESS</responseCode>\n  <count>1</count>\n  <data>\n    <Portal-Version>\n      <PortalApplication-VERSION>3.1.2.0-2 OFFICIAL #597 (2020-09-15T15:54:59Z)</PortalApplication-VERSION>\n      <ITAM-VERSION>1.2.1.1-1</ITAM-VERSION>\n      <CS-VERSION>1.6.8.2-23</CS-VERSION>\n      <CA-VERSION>2.23.0.0</CA-VERSION>\n      <QGS-VERSION>1.2.0.0-6</QGS-VERSION>\n      <QUESTIONNAIRE-VERSION>2.23.1.0</QUESTIONNAIRE-VERSION>\n      <WAF-VERSION>2.12.4.0</WAF-VERSION>\n      <QUESTIONNAIRE__V2-VERSION>1.10.1.0</QUESTIONNAIRE__V2-VERSION>\n      <WAS-VERSION>6.13.1.0</WAS-VERSION>\n      <FIM-VERSION>2.3.1.0</FIM-VERSION>\n      <VM-VERSION>1.0.3</VM-VERSION>\n      <CERTVIEW-VERSION>2.7.0.0-67</CERTVIEW-VERSION>\n      <CLOUDVIEW-VERSION>1.11.0.0-1</CLOUDVIEW-VERSION>\n      <CM-VERSION>1.30.0.0</CM-VERSION>\n      <MDS-VERSION>2.15.7.0</MDS-VERSION>\n      <PM-VERSION>1.4.3.0-289</PM-VERSION>\n      <PS-VERSION>1.2.1.0-4</PS-VERSION>\n      <IOC-VERSION>3.0.0.0-5</IOC-VERSION>\n      <THREAT__PROTECT-VERSION>1.2.0.0</THREAT__PROTECT-VERSION>\n      <AV2-VERSION>0.1.0</AV2-VERSION>\n      <UD-VERSION>0.0.6</UD-VERSION>\n    </Portal-Version>\n    <QWeb-Version>\n      <WEB-VERSION>10.3.0.3-2</WEB-VERSION>\n      <SCANNER-VERSION>12.1.67-1</SCANNER-VERSION>\n      <VULNSIGS-VERSION>2.5.13-2</VULNSIGS-VERSION>\n    </QWeb-Version>\n  </data>\n</ServiceResponse>"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "JSESSIONID",
+              "path": "/qps",
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 20 Oct 2020 17:16:00 GMT"
+            },
+            {
+              "name": "server",
+              "value": "Apache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1;mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            }
+          ],
+          "headersSize": 378,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-10-20T17:15:55.932Z",
+        "time": 4482,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 4482
+        }
+      },
+      {
+        "_id": "5cb93e99a45d412ac29b8aae666fd8f7",
+        "_order": 1,
+        "cache": {},
+        "request": {
+          "bodySize": 0,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "x-requested-with",
+              "value": "@jupiterone/graph-qualys"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "qualysapi.qg3.apps.qualys.com"
+            }
+          ],
+          "headersSize": 345,
+          "httpVersion": "HTTP/1.1",
+          "method": "GET",
+          "queryString": [],
+          "url": "https://qualysapi.qg3.apps.qualys.com/qps/rest/portal/version"
+        },
+        "response": {
+          "bodySize": 1343,
+          "content": {
+            "mimeType": "application/xml",
+            "size": 1343,
+            "text": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<ServiceResponse xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xsi:noNamespaceSchemaLocation=\"https://qualysapi.qg3.apps.qualys.com/qps/xsd/version.xsd\">\n  <responseCode>SUCCESS</responseCode>\n  <count>1</count>\n  <data>\n    <Portal-Version>\n      <PortalApplication-VERSION>3.1.2.0-2 OFFICIAL #597 (2020-09-15T15:54:59Z)</PortalApplication-VERSION>\n      <ITAM-VERSION>1.2.1.1-1</ITAM-VERSION>\n      <CS-VERSION>1.6.8.2-23</CS-VERSION>\n      <CA-VERSION>2.23.0.0</CA-VERSION>\n      <QGS-VERSION>1.2.0.0-6</QGS-VERSION>\n      <QUESTIONNAIRE-VERSION>2.23.1.0</QUESTIONNAIRE-VERSION>\n      <WAF-VERSION>2.12.4.0</WAF-VERSION>\n      <QUESTIONNAIRE__V2-VERSION>1.10.1.0</QUESTIONNAIRE__V2-VERSION>\n      <WAS-VERSION>6.13.1.0</WAS-VERSION>\n      <FIM-VERSION>2.3.1.0</FIM-VERSION>\n      <VM-VERSION>1.0.3</VM-VERSION>\n      <CERTVIEW-VERSION>2.7.0.0-67</CERTVIEW-VERSION>\n      <CLOUDVIEW-VERSION>1.11.0.0-1</CLOUDVIEW-VERSION>\n      <CM-VERSION>1.30.0.0</CM-VERSION>\n      <MDS-VERSION>2.15.7.0</MDS-VERSION>\n      <PM-VERSION>1.4.3.0-289</PM-VERSION>\n      <PS-VERSION>1.2.1.0-4</PS-VERSION>\n      <IOC-VERSION>3.0.0.0-5</IOC-VERSION>\n      <THREAT__PROTECT-VERSION>1.2.0.0</THREAT__PROTECT-VERSION>\n      <AV2-VERSION>0.1.0</AV2-VERSION>\n      <UD-VERSION>0.0.6</UD-VERSION>\n    </Portal-Version>\n    <QWeb-Version>\n      <WEB-VERSION>10.3.0.3-2</WEB-VERSION>\n      <SCANNER-VERSION>12.1.67-1</SCANNER-VERSION>\n      <VULNSIGS-VERSION>2.5.13-2</VULNSIGS-VERSION>\n    </QWeb-Version>\n  </data>\n</ServiceResponse>"
+          },
+          "cookies": [
+            {
+              "httpOnly": true,
+              "name": "JSESSIONID",
+              "path": "/qps",
+              "value": "[REDACTED]"
+            }
+          ],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "set-cookie",
+              "value": "[REDACTED]"
+            },
+            {
+              "name": "content-type",
+              "value": "application/xml"
+            },
+            {
+              "name": "vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "date",
+              "value": "Tue, 20 Oct 2020 17:16:04 GMT"
+            },
+            {
+              "name": "server",
+              "value": "Apache"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1;mode=block"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            }
+          ],
+          "headersSize": 378,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2020-10-20T17:16:00.430Z",
+        "time": 4417,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 4417
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/steps/__tests__/__snapshots__/index.test.ts.snap
+++ b/src/steps/__tests__/__snapshots__/index.test.ts.snap
@@ -1,5 +1,243 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`fetchScannedHostDetails: fetchScannedHostDetails 1`] = `
+Object {
+  "collectedEntities": Array [
+    Object {
+      "_class": Array [
+        "Account",
+      ],
+      "_key": "qualys-account:local-integration-instance",
+      "_rawData": Array [
+        Object {
+          "name": "default",
+          "rawData": Object {
+            "portal": Object {
+              "Portal-Version": Object {
+                "AV2-VERSION": "0.1.0",
+                "CA-VERSION": "2.23.0.0",
+                "CERTVIEW-VERSION": "2.7.0.0-67",
+                "CLOUDVIEW-VERSION": "1.11.0.0-1",
+                "CM-VERSION": "1.30.0.0",
+                "CS-VERSION": "1.6.8.2-23",
+                "FIM-VERSION": "2.3.1.0",
+                "IOC-VERSION": "3.0.0.0-5",
+                "ITAM-VERSION": "1.2.1.1-1",
+                "MDS-VERSION": "2.15.7.0",
+                "PM-VERSION": "1.4.3.0-289",
+                "PS-VERSION": "1.2.1.0-4",
+                "PortalApplication-VERSION": "3.1.2.0-2 OFFICIAL #597 (2020-09-15T15:54:59Z)",
+                "QGS-VERSION": "1.2.0.0-6",
+                "QUESTIONNAIRE-VERSION": "2.23.1.0",
+                "QUESTIONNAIRE__V2-VERSION": "1.10.1.0",
+                "THREAT__PROTECT-VERSION": "1.2.0.0",
+                "UD-VERSION": "0.0.6",
+                "VM-VERSION": "1.0.3",
+                "WAF-VERSION": "2.12.4.0",
+                "WAS-VERSION": "6.13.1.0",
+              },
+              "QWeb-Version": Object {
+                "SCANNER-VERSION": "12.1.67-1",
+                "VULNSIGS-VERSION": "2.5.13-2",
+                "WEB-VERSION": "10.3.0.3-2",
+              },
+            },
+          },
+        },
+      ],
+      "_type": "qualys_account",
+      "createdOn": undefined,
+      "displayName": "Qualys - Local Integration",
+      "name": "Qualys - Local Integration",
+    },
+    Object {
+      "_class": Array [
+        "Service",
+      ],
+      "_key": "qualys-service:was",
+      "_rawData": Array [],
+      "_type": "qualys_web_app_scanner",
+      "category": Array [
+        "software",
+        "other",
+      ],
+      "createdOn": undefined,
+      "description": "Automated Web Application Security Assessment and Reporting",
+      "displayName": "Qualys Web Application Scanner",
+      "function": "DAST",
+      "name": "Qualys Web Application Scanner",
+      "updatedOn": undefined,
+      "version": "6.13.1.0",
+    },
+    Object {
+      "_class": Array [
+        "Service",
+      ],
+      "_key": "qualys-service:vmdr",
+      "_rawData": Array [],
+      "_type": "qualys_vulnerability_manager",
+      "category": Array [
+        "software",
+        "other",
+      ],
+      "createdOn": undefined,
+      "description": "Detect, prioritize and remediate vulnerabilities, and monitor using dashboards.",
+      "displayName": "Qualys Vulnerability Manager",
+      "function": "vulnerability-management",
+      "name": "Qualys Vulnerability Manager",
+      "updatedOn": undefined,
+      "version": "1.0.3",
+    },
+  ],
+  "collectedRelationships": Array [
+    Object {
+      "_class": "HAS",
+      "_fromEntityKey": "qualys-account:local-integration-instance",
+      "_key": "qualys-account:local-integration-instance|has|qualys-service:was",
+      "_toEntityKey": "qualys-service:was",
+      "_type": "qualys_account_has_web_app_scanner",
+      "displayName": "HAS",
+    },
+    Object {
+      "_class": "HAS",
+      "_fromEntityKey": "qualys-account:local-integration-instance",
+      "_key": "qualys-account:local-integration-instance|has|qualys-service:vmdr",
+      "_toEntityKey": "qualys-service:vmdr",
+      "_type": "qualys_account_has_vulnerability_manager",
+      "displayName": "HAS",
+    },
+  ],
+  "encounteredTypes": Array [
+    "qualys_account",
+    "qualys_web_app_scanner",
+    "qualys_vulnerability_manager",
+    "qualys_account_has_web_app_scanner",
+    "qualys_account_has_vulnerability_manager",
+  ],
+  "numCollectedEntities": 3,
+  "numCollectedRelationships": 2,
+}
+`;
+
+exports[`fetchScannedHostFindings: fetchScannedHostFindings 1`] = `
+Object {
+  "collectedEntities": Array [
+    Object {
+      "_class": Array [
+        "Account",
+      ],
+      "_key": "qualys-account:local-integration-instance",
+      "_rawData": Array [
+        Object {
+          "name": "default",
+          "rawData": Object {
+            "portal": Object {
+              "Portal-Version": Object {
+                "AV2-VERSION": "0.1.0",
+                "CA-VERSION": "2.23.0.0",
+                "CERTVIEW-VERSION": "2.7.0.0-67",
+                "CLOUDVIEW-VERSION": "1.11.0.0-1",
+                "CM-VERSION": "1.30.0.0",
+                "CS-VERSION": "1.6.8.2-23",
+                "FIM-VERSION": "2.3.1.0",
+                "IOC-VERSION": "3.0.0.0-5",
+                "ITAM-VERSION": "1.2.1.1-1",
+                "MDS-VERSION": "2.15.7.0",
+                "PM-VERSION": "1.4.3.0-289",
+                "PS-VERSION": "1.2.1.0-4",
+                "PortalApplication-VERSION": "3.1.2.0-2 OFFICIAL #597 (2020-09-15T15:54:59Z)",
+                "QGS-VERSION": "1.2.0.0-6",
+                "QUESTIONNAIRE-VERSION": "2.23.1.0",
+                "QUESTIONNAIRE__V2-VERSION": "1.10.1.0",
+                "THREAT__PROTECT-VERSION": "1.2.0.0",
+                "UD-VERSION": "0.0.6",
+                "VM-VERSION": "1.0.3",
+                "WAF-VERSION": "2.12.4.0",
+                "WAS-VERSION": "6.13.1.0",
+              },
+              "QWeb-Version": Object {
+                "SCANNER-VERSION": "12.1.67-1",
+                "VULNSIGS-VERSION": "2.5.13-2",
+                "WEB-VERSION": "10.3.0.3-2",
+              },
+            },
+          },
+        },
+      ],
+      "_type": "qualys_account",
+      "createdOn": undefined,
+      "displayName": "Qualys - Local Integration",
+      "name": "Qualys - Local Integration",
+    },
+    Object {
+      "_class": Array [
+        "Service",
+      ],
+      "_key": "qualys-service:was",
+      "_rawData": Array [],
+      "_type": "qualys_web_app_scanner",
+      "category": Array [
+        "software",
+        "other",
+      ],
+      "createdOn": undefined,
+      "description": "Automated Web Application Security Assessment and Reporting",
+      "displayName": "Qualys Web Application Scanner",
+      "function": "DAST",
+      "name": "Qualys Web Application Scanner",
+      "updatedOn": undefined,
+      "version": "6.13.1.0",
+    },
+    Object {
+      "_class": Array [
+        "Service",
+      ],
+      "_key": "qualys-service:vmdr",
+      "_rawData": Array [],
+      "_type": "qualys_vulnerability_manager",
+      "category": Array [
+        "software",
+        "other",
+      ],
+      "createdOn": undefined,
+      "description": "Detect, prioritize and remediate vulnerabilities, and monitor using dashboards.",
+      "displayName": "Qualys Vulnerability Manager",
+      "function": "vulnerability-management",
+      "name": "Qualys Vulnerability Manager",
+      "updatedOn": undefined,
+      "version": "1.0.3",
+    },
+  ],
+  "collectedRelationships": Array [
+    Object {
+      "_class": "HAS",
+      "_fromEntityKey": "qualys-account:local-integration-instance",
+      "_key": "qualys-account:local-integration-instance|has|qualys-service:was",
+      "_toEntityKey": "qualys-service:was",
+      "_type": "qualys_account_has_web_app_scanner",
+      "displayName": "HAS",
+    },
+    Object {
+      "_class": "HAS",
+      "_fromEntityKey": "qualys-account:local-integration-instance",
+      "_key": "qualys-account:local-integration-instance|has|qualys-service:vmdr",
+      "_toEntityKey": "qualys-service:vmdr",
+      "_type": "qualys_account_has_vulnerability_manager",
+      "displayName": "HAS",
+    },
+  ],
+  "encounteredTypes": Array [
+    "qualys_account",
+    "qualys_web_app_scanner",
+    "qualys_vulnerability_manager",
+    "qualys_account_has_web_app_scanner",
+    "qualys_account_has_vulnerability_manager",
+  ],
+  "numCollectedEntities": 3,
+  "numCollectedRelationships": 2,
+}
+`;
+
 exports[`steps 1`] = `
 Object {
   "collectedEntities": Array [

--- a/src/steps/__tests__/index.test.ts
+++ b/src/steps/__tests__/index.test.ts
@@ -98,3 +98,55 @@ test('steps', async () => {
     },
   });
 });
+
+test('fetchScannedHostDetails', async () => {
+  recording = setupQualysRecording({
+    directory: __dirname,
+    name: 'fetchScannedHostDetails',
+  });
+
+  const nowTimestamp = 1599865230000; // '2020-09-11T23:00:30Z';
+  jest.spyOn(Date, 'now').mockImplementation(() => nowTimestamp);
+
+  const context = createMockStepExecutionContext<QualysIntegrationConfig>({
+    instanceConfig: config,
+  });
+
+  await fetchAccountDetails(context);
+  await fetchServices(context);
+  await fetchScannedHostDetails(context);
+
+  expect({
+    numCollectedEntities: context.jobState.collectedEntities.length,
+    numCollectedRelationships: context.jobState.collectedRelationships.length,
+    collectedEntities: context.jobState.collectedEntities,
+    collectedRelationships: context.jobState.collectedRelationships,
+    encounteredTypes: context.jobState.encounteredTypes,
+  }).toMatchSnapshot('fetchScannedHostDetails');
+});
+
+test('fetchScannedHostFindings', async () => {
+  recording = setupQualysRecording({
+    directory: __dirname,
+    name: 'fetchScannedHostFindings',
+  });
+
+  const nowTimestamp = 1599865230000; // '2020-09-11T23:00:30Z';
+  jest.spyOn(Date, 'now').mockImplementation(() => nowTimestamp);
+
+  const context = createMockStepExecutionContext<QualysIntegrationConfig>({
+    instanceConfig: config,
+  });
+
+  await fetchAccountDetails(context);
+  await fetchServices(context);
+  await fetchScannedHostFindings(context);
+
+  expect({
+    numCollectedEntities: context.jobState.collectedEntities.length,
+    numCollectedRelationships: context.jobState.collectedRelationships.length,
+    collectedEntities: context.jobState.collectedEntities,
+    collectedRelationships: context.jobState.collectedRelationships,
+    encounteredTypes: context.jobState.encounteredTypes,
+  }).toMatchSnapshot('fetchScannedHostFindings');
+});

--- a/src/steps/vmdr/index.ts
+++ b/src/steps/vmdr/index.ts
@@ -102,7 +102,8 @@ export async function fetchScannedHostDetails({
   instance,
   jobState,
 }: IntegrationStepExecutionContext<QualysIntegrationConfig>) {
-  const hostIds = (await jobState.getData(DATA_SCANNED_HOST_IDS)) as number[];
+  const hostIds = ((await jobState.getData(DATA_SCANNED_HOST_IDS)) ||
+    []) as number[];
   const vdmrServiceEntity = (await jobState.getData(
     DATA_VMDR_SERVICE_ENTITY,
   )) as Entity;
@@ -153,7 +154,9 @@ export async function fetchScannedHostDetails({
 
   logger.publishEvent({
     name: 'stats',
-    description: `Processed ${totalHostsProcessed} host details${
+    description: `Processed details for ${totalHostsProcessed} of ${
+      hostIds.length
+    } hosts${
       totalPageErrors > 0
         ? `, encountered errors on ${totalPageErrors} pages (errorId="${errorCorrelationId}")`
         : ''
@@ -174,10 +177,10 @@ export async function fetchScannedHostFindings({
 }: IntegrationStepExecutionContext<QualysIntegrationConfig>) {
   const apiClient = createQualysAPIClient(logger, instance.config);
 
-  const hostIds = (await jobState.getData(DATA_SCANNED_HOST_IDS)) as number[];
-  const hostTargetsMap = (await jobState.getData(
-    DATA_HOST_TARGETS,
-  )) as HostAssetTargetsMap;
+  const hostIds = ((await jobState.getData(DATA_SCANNED_HOST_IDS)) ||
+    []) as number[];
+  const hostTargetsMap = ((await jobState.getData(DATA_HOST_TARGETS)) ||
+    {}) as HostAssetTargetsMap;
 
   const serviceEntity = (await jobState.getData(
     DATA_VMDR_SERVICE_ENTITY,
@@ -254,7 +257,9 @@ export async function fetchScannedHostFindings({
 
   logger.publishEvent({
     name: 'stats',
-    description: `Processed detections for ${totalHostsProcessed} hosts${
+    description: `Processed detections for ${totalHostsProcessed} of ${
+      hostIds.length
+    } hosts${
       totalPageErrors > 0
         ? `, encountered errors on ${totalPageErrors} pages (errorId="${errorCorrelationId}")`
         : ''


### PR DESCRIPTION
Handles two cases:

1. No hosts that have been scanned
2. `404` responses fetching host details from asset manager API

I don't know why the asset manager API would answer a `404` response when requesting details for hosts that were seen in VM API. When that happens, the steps will now avoid crashing, but we'll end up with no `Host` entities. The customer will see a job log event indicating that we received errors from the Qualys API, and these are logged at `level: 50`.