### PR TITLE
Update config field to defaultValue

### DIFF
--- a/src/instanceConfigFields.ts
+++ b/src/instanceConfigFields.ts
@@ -13,7 +13,7 @@ const instanceConfigFields: IntegrationInstanceConfigFieldMap = {
   },
 
   // TODO: Support multiselect, default selections, no selection
-  // TODO: Support numeric values, default value
+  // TODO: Use field definitions from open source projects to remove duplication
 
   /**
    * Adds finding request filter parameter `"type"`.
@@ -35,7 +35,7 @@ const instanceConfigFields: IntegrationInstanceConfigFieldMap = {
   // wasFindingSeverityLevels: {
   //   type: 'string',
   //   // options: [1,2,3,4,5],
-  //   // default: [3,4,5]
+  //   // defaultValue: [3,4,5]
   // },
 
   /**
@@ -50,7 +50,7 @@ const instanceConfigFields: IntegrationInstanceConfigFieldMap = {
   // wasIgnoredReasons: {
   //   type: 'string',
   //   // options: ['FALSE_POSITIVE', 'RISK_ACCEPTED', 'NOT_APPLICABLE']
-  //   // default: []
+  //   // defaultValue: []
   // },
 
   /**
@@ -64,7 +64,7 @@ const instanceConfigFields: IntegrationInstanceConfigFieldMap = {
   // vmdrFindingSeverities: {
   //   type: 'string',
   //   // options: [1,2,3,4,5]
-  //   // default: [3,4,5]
+  //   // defaultValue: [3,4,5]
   // },
 
   /**
@@ -88,7 +88,7 @@ const instanceConfigFields: IntegrationInstanceConfigFieldMap = {
   // vmdrFindingStatuses: {
   //   type:'string',
   //   options: ['New', 'Active', 'Re-Opened', 'Fixed'],
-  //   default: ['New', 'Active', 'Re-Opened']
+  //   defaultValue: ['New', 'Active', 'Re-Opened']
   // },
 
   /**
@@ -103,7 +103,7 @@ const instanceConfigFields: IntegrationInstanceConfigFieldMap = {
   // vmdrFindingTypes: {
   //   type: 'string',
   //   // options: ['Confirmed', 'Potential', 'Information'],
-  //   // default: ['Confirmed', 'Potential', 'Information'],
+  //   // defaultValue: ['Confirmed', 'Potential', 'Information'],
   // },
 
   /**
@@ -115,7 +115,7 @@ const instanceConfigFields: IntegrationInstanceConfigFieldMap = {
    */
   // vmdrFindingIngored: {
   //   type: 'boolean',
-  //   default: false
+  //   defaultValue: false
   // }
 
   /**
@@ -131,7 +131,7 @@ const instanceConfigFields: IntegrationInstanceConfigFieldMap = {
    */
   minScannedSinceDays: {
     type: 'string',
-    // default: DEFAULT_SCANNED_SINCE_DAYS
+    // defaultValue: DEFAULT_SCANNED_SINCE_DAYS
   },
 
   /**
@@ -147,7 +147,7 @@ const instanceConfigFields: IntegrationInstanceConfigFieldMap = {
    */
   minFindingsSinceDays: {
     type: 'string',
-    // default: DEFAULT_FINDINGS_SINCE_DAYS
+    // defaultValue: DEFAULT_FINDINGS_SINCE_DAYS
   },
 };
 


### PR DESCRIPTION
Using `default` turned out to be problematic since it is a keyword in JS. This avoids confusion. These are commented out because the actual `defaultValue` is set in the integration definition for use by the configuration UI.

A bit of background...

The integration SDK requires that integrations provide `instanceConfigFields` to drive loading local configuration from the process env. It would be ideal to have the `validateInvocation` function use the `instanceConfigFields` to verify the configuration, and also load default values such as these from the config.

The managed integration deployment projects contain integration definition files, which is where the information for the configuration UI comes from today. It would be ideal to have the configuration UI driven from `instanceConfigFields` as well.

This file in the Qualys integration:

1. Captures some TODOs for where we need to go in configuring the integration
2. Documents what the default values will be, even though they're not yet obtained from this config
3. Advances the design goal of moving all the integration config stuff into the integrations and out of the definition