### PR TITLE
INT-1199 Add validation of active endpoints prior to running integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## 4.5.0 - 2020-10-29
+
+### Added
+
+- Configuration check that the api url starts with qualysapi
+
 ## 4.4.0 - 2020-10-29
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-qualys",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Qualys integration for JupiterOne",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/provider/client.test.ts
+++ b/src/provider/client.test.ts
@@ -20,6 +20,7 @@ import {
   vmpc,
   was,
 } from './client';
+import { IntegrationValidationError } from '@jupiterone/integration-sdk-core';
 
 jest.setTimeout(1000 * 60 * 1);
 
@@ -434,6 +435,20 @@ describe('verifyAuthentication', () => {
     await expect(
       createClient().verifyAuthentication(),
     ).resolves.not.toThrowError();
+  });
+});
+
+describe('validateApiUrl', () => {
+  test('invalid', () => {
+    const invalidApiUrl = 'https://qualysguard.qg3.apps.qualys.com';
+    const client = new QualysAPIClient({
+      config: { ...config, qualysApiUrl: invalidApiUrl },
+    });
+    expect(() => client.validateApiUrl()).toThrow(IntegrationValidationError);
+  });
+
+  test('valid', () => {
+    expect(() => createClient().validateApiUrl()).not.toThrowError();
   });
 });
 

--- a/src/provider/client/index.ts
+++ b/src/provider/client/index.ts
@@ -228,6 +228,15 @@ export class QualysAPIClient {
     }
   }
 
+  public validateApiUrl(): void {
+    const apiUrlPrefix = 'https://qualysapi';
+    if (!this.config.qualysApiUrl.startsWith(apiUrlPrefix)) {
+      throw new IntegrationValidationError(
+        `Api url does not begin with ${apiUrlPrefix}. Please ensure you are providing the api url specified by your Qualys platform host as seen under the "API URLs" section here: https://www.qualys.com/platform-identification/`,
+      );
+    }
+  }
+
   public async fetchPortalInfo(): Promise<PortalInfo | undefined> {
     const endpoint = '/qps/rest/portal/version';
 

--- a/src/provider/client/index.ts
+++ b/src/provider/client/index.ts
@@ -11,6 +11,7 @@ import { v4 as uuid } from 'uuid';
 import {
   IntegrationProviderAPIError,
   IntegrationProviderAuthenticationError,
+  IntegrationValidationError,
 } from '@jupiterone/integration-sdk-core';
 
 import { QualysIntegrationConfig } from '../../types';

--- a/src/validateInvocation.test.ts
+++ b/src/validateInvocation.test.ts
@@ -20,6 +20,7 @@ beforeEach(() => {
   jest.spyOn(Date, 'now').mockImplementation(() => 1602528224084);
   (createQualysAPIClient as jest.Mock).mockReturnValue({
     verifyAuthentication: jest.fn(),
+    validateApiUrl: jest.fn(),
   });
 });
 

--- a/src/validateInvocation.ts
+++ b/src/validateInvocation.ts
@@ -67,6 +67,7 @@ export default async function validateInvocation({
 
   const client = createQualysAPIClient(logger, config);
   await client.verifyAuthentication();
+  client.validateApiUrl();
 }
 
 function readPropertyFromEnv(propertyName: string): string | undefined {


### PR DESCRIPTION
Add a validation that the configured apiUrl starts with qualysapi <- fixes the problem found in sentury.
Also includes a refactor of pulling out all url paths to the constants folder.