### PR TITLE
Use execution history to ingest partial finding data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade `@jupiterone/integration-sdk-*@4.2.0`
+- `context.history` is used to ingest scans/findings since last successful
+  execution
+- Mark apps, hosts, and findings as partial data sets so that previous findings
+  are not deleted during synchronization
+
 ## 4.5.0 - 2020-10-29
 
 ### Added
@@ -12,7 +20,7 @@
 
 ### Changed
 
-- Upgrade SDK v4
+- Upgrade `@jupiterone/integration-sdk-*@4.0.0`
 
 ## 4.3.1 2020-10-20
 

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-core": "^4.1.0",
-    "@jupiterone/integration-sdk-dev-tools": "^4.1.0",
-    "@jupiterone/integration-sdk-testing": "^4.1.0",
+    "@jupiterone/integration-sdk-core": "^4.2.0",
+    "@jupiterone/integration-sdk-dev-tools": "^4.2.0",
+    "@jupiterone/integration-sdk-testing": "^4.2.0",
     "@prettier/plugin-xml": "^0.12.0",
     "@types/await-timeout": "^0.3.1",
     "@types/lodash": "^4.14.161",
@@ -52,6 +52,6 @@
     "ts-node": "^8.8.2"
   },
   "peerDependencies": {
-    "@jupiterone/integration-sdk-core": "^4.1.0"
+    "@jupiterone/integration-sdk-core": "^4.2.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     "uuid": "^8.3.1"
   },
   "devDependencies": {
-    "@jupiterone/integration-sdk-core": "^4.0.0",
-    "@jupiterone/integration-sdk-dev-tools": "^4.0.0",
-    "@jupiterone/integration-sdk-testing": "^4.0.0",
+    "@jupiterone/integration-sdk-core": "^4.1.0",
+    "@jupiterone/integration-sdk-dev-tools": "^4.1.0",
+    "@jupiterone/integration-sdk-testing": "^4.1.0",
     "@prettier/plugin-xml": "^0.12.0",
     "@types/await-timeout": "^0.3.1",
     "@types/lodash": "^4.14.161",
@@ -52,6 +52,6 @@
     "ts-node": "^8.8.2"
   },
   "peerDependencies": {
-    "@jupiterone/integration-sdk-core": "^4.0.0"
+    "@jupiterone/integration-sdk-core": "^4.1.0"
   }
 }

--- a/src/instanceConfigFields.ts
+++ b/src/instanceConfigFields.ts
@@ -134,6 +134,12 @@ const instanceConfigFields: IntegrationInstanceConfigFieldMap = {
     // defaultValue: DEFAULT_SCANNED_SINCE_DAYS
   },
 
+  // TODO Add support for virtual fields
+  // minScannedSinceISODate: {
+  //   type: 'string',
+  //   // virtual: true,
+  // },
+
   /**
    * Adds host detections request filter parameter `"detection_updated_since"`
    * by calculating the time since the current execution start time.
@@ -149,6 +155,12 @@ const instanceConfigFields: IntegrationInstanceConfigFieldMap = {
     type: 'string',
     // defaultValue: DEFAULT_FINDINGS_SINCE_DAYS
   },
+
+  // TODO Add support for virtual fields
+  // minFindingsSinceISODate: {
+  //   type: 'string',
+  //   // virtual: true,
+  // },
 };
 
 export default instanceConfigFields;

--- a/src/steps/index.ts
+++ b/src/steps/index.ts
@@ -1,6 +1,7 @@
 import { accountSteps } from './account';
 import { serviceSteps } from './services';
 import { hostDetectionSteps } from './vmdr';
+// TODO: Ingest vulnerability information
 // import { vulnSteps } from './vulns';
 import { webApplicationSteps } from './was';
 

--- a/src/steps/vmdr/constants.ts
+++ b/src/steps/vmdr/constants.ts
@@ -1,6 +1,8 @@
 import {
   generateRelationshipType,
   RelationshipClass,
+  StepEntityMetadata,
+  StepRelationshipMetadata,
 } from '@jupiterone/integration-sdk-core';
 
 import { ENTITY_TYPE_SERVICE_VMDR } from '../services';
@@ -36,31 +38,35 @@ export const MAPPED_RELATIONSHIP_TYPE_VDMR_EC2_HOST = generateRelationshipType(
   ENTITY_TYPE_EC2_HOST,
 );
 
-export const VmdrEntities = {
+export const VmdrEntities: Record<string, StepEntityMetadata> = {
   HOST_FINDING: {
     _type: ENTITY_TYPE_HOST_FINDING,
     _class: 'Finding',
     resourceName: 'Host Detection',
+    partial: true,
   },
 };
 
-export const VmdrRelationships = {
+export const VmdrRelationships: Record<string, StepRelationshipMetadata> = {
   SERVICE_HOST_FINDING: {
     _type: RELATIONSHIP_TYPE_SERVICE_HOST_FINDING,
     _class: RelationshipClass.IDENTIFIED,
     sourceType: ENTITY_TYPE_SERVICE_VMDR,
     targetType: ENTITY_TYPE_HOST_FINDING,
+    partial: true,
   },
   SERVICE_DISCOVERED_HOST: {
     _type: MAPPED_RELATIONSHIP_TYPE_VDMR_DISCOVERED_HOST,
     _class: RelationshipClass.SCANS,
     sourceType: ENTITY_TYPE_SERVICE_VMDR,
     targetType: ENTITY_TYPE_DISCOVERED_HOST,
+    partial: true,
   },
   SERVICE_EC2_HOST: {
     _type: MAPPED_RELATIONSHIP_TYPE_VDMR_EC2_HOST,
     _class: RelationshipClass.SCANS,
     sourceType: ENTITY_TYPE_SERVICE_VMDR,
     targetType: ENTITY_TYPE_EC2_HOST,
+    partial: true,
   },
 };

--- a/src/steps/vulns/constants.ts
+++ b/src/steps/vulns/constants.ts
@@ -1,6 +1,7 @@
 import {
   generateRelationshipType,
   RelationshipClass,
+  StepRelationshipMetadata,
 } from '@jupiterone/integration-sdk-core';
 
 import { ENTITY_TYPE_HOST_FINDING } from '../vmdr/constants';
@@ -39,29 +40,33 @@ export const MAPPED_RELATIONSHIP_TYPE_WEBAPP_FINDING_QUALYS_VULNERABILITY = gene
   ENTITY_TYPE_QUALYS_VULNERABILITY,
 );
 
-export const VulnRelationships = {
+export const VulnRelationships: Record<string, StepRelationshipMetadata> = {
   HOST_FINDING_QUALYS_VULN: {
     _type: MAPPED_RELATIONSHIP_TYPE_HOST_FINDING_QUALYS_VULNERABILITY,
     _class: RelationshipClass.IS,
     sourceType: ENTITY_TYPE_HOST_FINDING,
     targetType: ENTITY_TYPE_QUALYS_VULNERABILITY,
+    partial: true,
   },
   HOST_FINDING_CVE_VULN: {
     _type: MAPPED_RELATIONSHIP_TYPE_HOST_FINDING_CVE_VULNERABILITY,
     _class: RelationshipClass.IS,
     sourceType: ENTITY_TYPE_HOST_FINDING,
     targetType: ENTITY_TYPE_CVE_VULNERABILITY,
+    partial: true,
   },
   WEBAPP_FINDING_QUALYS_VULN: {
     _type: MAPPED_RELATIONSHIP_TYPE_WEBAPP_FINDING_QUALYS_VULNERABILITY,
     _class: RelationshipClass.IS,
     sourceType: ENTITY_TYPE_WEBAPP_FINDING,
     targetType: ENTITY_TYPE_QUALYS_VULNERABILITY,
+    partial: true,
   },
   WEBAPP_FINDING_CVE_VULN: {
     _type: MAPPED_RELATIONSHIP_TYPE_WEBAPP_FINDING_CVE_VULNERABILITY,
     _class: RelationshipClass.IS,
     sourceType: ENTITY_TYPE_WEBAPP_FINDING,
     targetType: ENTITY_TYPE_CVE_VULNERABILITY,
+    partial: true,
   },
 };

--- a/src/steps/was/constants.ts
+++ b/src/steps/was/constants.ts
@@ -1,6 +1,8 @@
 import {
   generateRelationshipType,
   RelationshipClass,
+  StepEntityMetadata,
+  StepRelationshipMetadata,
 } from '@jupiterone/integration-sdk-core';
 
 import { ENTITY_TYPE_SERVICE_WAS } from '../services';
@@ -28,25 +30,28 @@ export const MAPPED_RELATIONSHIP_TYPE_WAS_SCANS_WEBAPP = generateRelationshipTyp
   ENTITY_TYPE_WEBAPP,
 );
 
-export const WasEntities = {
+export const WasEntities: Record<string, StepEntityMetadata> = {
   WEBAPP_FINDING: {
     _type: ENTITY_TYPE_WEBAPP_FINDING,
     _class: 'Finding',
     resourceName: 'Web App Finding',
+    partial: true,
   },
 };
 
-export const WasRelationships = {
+export const WasRelationships: Record<string, StepRelationshipMetadata> = {
   SERVICE_WEBAPP_FINDING: {
     _type: RELATIONSHIP_TYPE_SERVICE_WEBAPP_FINDING,
     _class: RelationshipClass.IDENTIFIED,
     sourceType: ENTITY_TYPE_SERVICE_WAS,
     targetType: ENTITY_TYPE_WEBAPP_FINDING,
+    partial: true,
   },
   SERVICE_SCANS_WEBAPP: {
     _type: MAPPED_RELATIONSHIP_TYPE_WAS_SCANS_WEBAPP,
     _class: RelationshipClass.SCANS,
     sourceType: ENTITY_TYPE_SERVICE_WAS,
     targetType: ENTITY_TYPE_WEBAPP,
+    partial: true,
   },
 };

--- a/src/validateInvocation.test.ts
+++ b/src/validateInvocation.test.ts
@@ -118,6 +118,17 @@ describe('minScannedSinceDays', () => {
     );
   });
 
+  test('numeric float allows less than one day', async () => {
+    const context = createMockExecutionContext<QualysIntegrationConfig>({
+      instanceConfig: createInstanceConfig({ minScannedSinceDays: 0.166 }),
+    });
+    await validateInvocation(context);
+    expect(context.instance.config.minScannedSinceDays).toEqual(0.166);
+    expect(context.instance.config.minScannedSinceISODate).toEqual(
+      '2020-10-12T14:44:41Z',
+    );
+  });
+
   test('MIN_SCANNED_SINCE_DAYS environment variable', async () => {
     process.env.MIN_SCANNED_SINCE_DAYS = '91';
     const context = createMockExecutionContext<QualysIntegrationConfig>({
@@ -257,6 +268,17 @@ describe('minFindingsSinceDays', () => {
     expect(context.instance.config.minFindingsSinceDays).toEqual(91);
     expect(context.instance.config.minFindingsSinceISODate).toEqual(
       '2020-07-13T18:43:44Z',
+    );
+  });
+
+  test('numeric float allows less than one day', async () => {
+    const context = createMockExecutionContext<QualysIntegrationConfig>({
+      instanceConfig: createInstanceConfig({ minFindingsSinceDays: 0.166 }),
+    });
+    await validateInvocation(context);
+    expect(context.instance.config.minFindingsSinceDays).toEqual(0.166);
+    expect(context.instance.config.minFindingsSinceISODate).toEqual(
+      '2020-10-12T14:44:41Z',
     );
   });
 

--- a/src/validateInvocation.test.ts
+++ b/src/validateInvocation.test.ts
@@ -1,3 +1,7 @@
+import {
+  Execution,
+  IntegrationExecutionContext,
+} from '@jupiterone/integration-sdk-core';
 import { createMockExecutionContext } from '@jupiterone/integration-sdk-testing';
 
 import {
@@ -10,11 +14,16 @@ import validateInvocation from './validateInvocation';
 
 jest.mock('./provider/createQualysAPIClient');
 
-const config = {
-  qualysApiUrl: 'https://qualysapi.qualys.com',
-  qualysUsername: 'username123',
-  qualysPassword: 'passwordabc',
-} as QualysIntegrationConfig;
+function createInstanceConfig(
+  overrides?: Partial<QualysIntegrationConfig>,
+): QualysIntegrationConfig {
+  return {
+    qualysApiUrl: 'https://qualysapi.qualys.com',
+    qualysUsername: 'username123',
+    qualysPassword: 'passwordabc',
+    ...overrides,
+  } as QualysIntegrationConfig;
+}
 
 beforeEach(() => {
   jest.spyOn(Date, 'now').mockImplementation(() => 1602528224084);
@@ -29,9 +38,15 @@ afterEach(() => {
 });
 
 describe('minScannedSinceDays', () => {
+  beforeEach(() => {
+    delete process.env.MIN_SCANNED_SINCE_DAYS;
+  });
+
   test('undefined on existing configs', async () => {
     const context = createMockExecutionContext<QualysIntegrationConfig>({
-      instanceConfig: { ...config, minScannedSinceDays: undefined as any },
+      instanceConfig: createInstanceConfig({
+        minScannedSinceDays: undefined as any,
+      }),
     });
     await validateInvocation(context);
     expect(context.instance.config.minScannedSinceDays).toEqual(
@@ -44,7 +59,7 @@ describe('minScannedSinceDays', () => {
 
   test('empty string', async () => {
     const context = createMockExecutionContext<QualysIntegrationConfig>({
-      instanceConfig: { ...config, minScannedSinceDays: ' ' as any },
+      instanceConfig: createInstanceConfig({ minScannedSinceDays: ' ' as any }),
     });
     await validateInvocation(context);
     expect(context.instance.config.minScannedSinceDays).toEqual(
@@ -57,7 +72,9 @@ describe('minScannedSinceDays', () => {
 
   test('non-numeric string', async () => {
     const context = createMockExecutionContext<QualysIntegrationConfig>({
-      instanceConfig: { ...config, minScannedSinceDays: ' abc' as any },
+      instanceConfig: createInstanceConfig({
+        minScannedSinceDays: ' abc' as any,
+      }),
     });
     await expect(validateInvocation(context)).rejects.toThrow(
       /minScannedSinceDays/,
@@ -66,7 +83,9 @@ describe('minScannedSinceDays', () => {
 
   test('numeric string', async () => {
     const context = createMockExecutionContext<QualysIntegrationConfig>({
-      instanceConfig: { ...config, minScannedSinceDays: '91' as any },
+      instanceConfig: createInstanceConfig({
+        minScannedSinceDays: '91' as any,
+      }),
     });
     await validateInvocation(context);
     expect(context.instance.config.minScannedSinceDays).toEqual(91);
@@ -77,7 +96,9 @@ describe('minScannedSinceDays', () => {
 
   test('numeric string with spaces', async () => {
     const context = createMockExecutionContext<QualysIntegrationConfig>({
-      instanceConfig: { ...config, minScannedSinceDays: ' 91 ' as any },
+      instanceConfig: createInstanceConfig({
+        minScannedSinceDays: ' 91 ' as any,
+      }),
     });
     await validateInvocation(context);
     expect(context.instance.config.minScannedSinceDays).toEqual(91);
@@ -88,7 +109,7 @@ describe('minScannedSinceDays', () => {
 
   test('numeric', async () => {
     const context = createMockExecutionContext<QualysIntegrationConfig>({
-      instanceConfig: { ...config, minScannedSinceDays: 91 },
+      instanceConfig: createInstanceConfig({ minScannedSinceDays: 91 }),
     });
     await validateInvocation(context);
     expect(context.instance.config.minScannedSinceDays).toEqual(91);
@@ -100,12 +121,58 @@ describe('minScannedSinceDays', () => {
   test('MIN_SCANNED_SINCE_DAYS environment variable', async () => {
     process.env.MIN_SCANNED_SINCE_DAYS = '91';
     const context = createMockExecutionContext<QualysIntegrationConfig>({
-      instanceConfig: config,
+      instanceConfig: createInstanceConfig(),
     });
     await validateInvocation(context);
     expect(context.instance.config.minScannedSinceDays).toEqual(91);
     expect(context.instance.config.minScannedSinceISODate).toEqual(
       '2020-07-13T18:43:44Z',
+    );
+  });
+
+  test('last successful execution used when less than since days', async () => {
+    const lastExecution: Execution = {
+      startedOn: Date.now(),
+    };
+
+    const context: IntegrationExecutionContext<QualysIntegrationConfig> = {
+      ...createMockExecutionContext<QualysIntegrationConfig>({
+        instanceConfig: createInstanceConfig({ minScannedSinceDays: 3 }),
+      }),
+      history: {
+        lastExecution,
+        lastSuccessfulExecution: lastExecution,
+      },
+    };
+
+    await validateInvocation(context);
+
+    expect(context.instance.config.minScannedSinceDays).toEqual(3);
+    expect(context.instance.config.minScannedSinceISODate).toEqual(
+      '2020-10-12T18:43:44Z',
+    );
+  });
+
+  test('last successful execution NOT used when greater than since days', async () => {
+    const lastExecution: Execution = {
+      startedOn: Date.now() - 10 * (1000 * 60 * 60 * 24),
+    };
+
+    const context: IntegrationExecutionContext<QualysIntegrationConfig> = {
+      ...createMockExecutionContext<QualysIntegrationConfig>({
+        instanceConfig: createInstanceConfig({ minScannedSinceDays: 3 }),
+      }),
+      history: {
+        lastExecution,
+        lastSuccessfulExecution: lastExecution,
+      },
+    };
+
+    await validateInvocation(context);
+
+    expect(context.instance.config.minScannedSinceDays).toEqual(3);
+    expect(context.instance.config.minScannedSinceISODate).toEqual(
+      '2020-10-09T18:43:44Z',
     );
   });
 });
@@ -117,7 +184,9 @@ describe('minFindingsSinceDays', () => {
 
   test('undefined on existing configs', async () => {
     const context = createMockExecutionContext<QualysIntegrationConfig>({
-      instanceConfig: { ...config, minFindingsSinceDays: undefined as any },
+      instanceConfig: createInstanceConfig({
+        minFindingsSinceDays: undefined as any,
+      }),
     });
     await validateInvocation(context);
     expect(context.instance.config.minFindingsSinceDays).toEqual(
@@ -130,7 +199,9 @@ describe('minFindingsSinceDays', () => {
 
   test('empty string', async () => {
     const context = createMockExecutionContext<QualysIntegrationConfig>({
-      instanceConfig: { ...config, minFindingsSinceDays: ' ' as any },
+      instanceConfig: createInstanceConfig({
+        minFindingsSinceDays: ' ' as any,
+      }),
     });
     await validateInvocation(context);
     expect(context.instance.config.minFindingsSinceDays).toEqual(
@@ -143,7 +214,9 @@ describe('minFindingsSinceDays', () => {
 
   test('non-numeric string', async () => {
     const context = createMockExecutionContext<QualysIntegrationConfig>({
-      instanceConfig: { ...config, minFindingsSinceDays: ' abc' as any },
+      instanceConfig: createInstanceConfig({
+        minFindingsSinceDays: ' abc' as any,
+      }),
     });
     await expect(validateInvocation(context)).rejects.toThrow(
       /minFindingsSinceDays/,
@@ -152,7 +225,9 @@ describe('minFindingsSinceDays', () => {
 
   test('numeric string', async () => {
     const context = createMockExecutionContext<QualysIntegrationConfig>({
-      instanceConfig: { ...config, minFindingsSinceDays: '91' as any },
+      instanceConfig: createInstanceConfig({
+        minFindingsSinceDays: '91' as any,
+      }),
     });
     await validateInvocation(context);
     expect(context.instance.config.minFindingsSinceDays).toEqual(91);
@@ -163,7 +238,9 @@ describe('minFindingsSinceDays', () => {
 
   test('numeric string with spaces', async () => {
     const context = createMockExecutionContext<QualysIntegrationConfig>({
-      instanceConfig: { ...config, minFindingsSinceDays: ' 91 ' as any },
+      instanceConfig: createInstanceConfig({
+        minFindingsSinceDays: ' 91 ' as any,
+      }),
     });
     await validateInvocation(context);
     expect(context.instance.config.minFindingsSinceDays).toEqual(91);
@@ -174,7 +251,7 @@ describe('minFindingsSinceDays', () => {
 
   test('numeric', async () => {
     const context = createMockExecutionContext<QualysIntegrationConfig>({
-      instanceConfig: { ...config, minFindingsSinceDays: 91 },
+      instanceConfig: createInstanceConfig({ minFindingsSinceDays: 91 }),
     });
     await validateInvocation(context);
     expect(context.instance.config.minFindingsSinceDays).toEqual(91);
@@ -186,12 +263,58 @@ describe('minFindingsSinceDays', () => {
   test('MIN_FINDINGS_SINCE_DAYS environment variable', async () => {
     process.env.MIN_FINDINGS_SINCE_DAYS = '91';
     const context = createMockExecutionContext<QualysIntegrationConfig>({
-      instanceConfig: config,
+      instanceConfig: createInstanceConfig(),
     });
     await validateInvocation(context);
     expect(context.instance.config.minFindingsSinceDays).toEqual(91);
     expect(context.instance.config.minFindingsSinceISODate).toEqual(
       '2020-07-13T18:43:44Z',
+    );
+  });
+
+  test('last successful execution used when less than since days', async () => {
+    const lastExecution: Execution = {
+      startedOn: Date.now(),
+    };
+
+    const context: IntegrationExecutionContext<QualysIntegrationConfig> = {
+      ...createMockExecutionContext<QualysIntegrationConfig>({
+        instanceConfig: createInstanceConfig({ minFindingsSinceDays: 3 }),
+      }),
+      history: {
+        lastExecution,
+        lastSuccessfulExecution: lastExecution,
+      },
+    };
+
+    await validateInvocation(context);
+
+    expect(context.instance.config.minFindingsSinceDays).toEqual(3);
+    expect(context.instance.config.minFindingsSinceISODate).toEqual(
+      '2020-10-12T18:43:44Z',
+    );
+  });
+
+  test('last successful execution NOT used when greater than since days', async () => {
+    const lastExecution: Execution = {
+      startedOn: Date.now() - 10 * (1000 * 60 * 60 * 24),
+    };
+
+    const context: IntegrationExecutionContext<QualysIntegrationConfig> = {
+      ...createMockExecutionContext<QualysIntegrationConfig>({
+        instanceConfig: createInstanceConfig({ minFindingsSinceDays: 3 }),
+      }),
+      history: {
+        lastExecution,
+        lastSuccessfulExecution: lastExecution,
+      },
+    };
+
+    await validateInvocation(context);
+
+    expect(context.instance.config.minFindingsSinceDays).toEqual(3);
+    expect(context.instance.config.minFindingsSinceISODate).toEqual(
+      '2020-10-09T18:43:44Z',
     );
   });
 });

--- a/src/validateInvocation.ts
+++ b/src/validateInvocation.ts
@@ -78,11 +78,21 @@ export default async function validateInvocation({
     config.minFindingsSinceISODate = isoDate(minFindingsSinceTime);
   }
 
-  // TODO: The SDK should be logging this information; the serializer for
-  // integrationInstanceConfig will prevent logging masked or fields not
-  // declared in the instanceConfigFields.
   logger.info(
-    { integrationInstanceConfig: config },
+    {
+      // TODO: The SDK should be safely logging; the serializer for
+      // integrationInstanceConfig will prevent logging masked fields or fields
+      // not declared in the instanceConfigFields.
+      integrationInstanceConfig: config,
+
+      lastSuccessfulExecutionTime: lastSuccessfulExecutionTime
+        ? isoDate(lastSuccessfulExecutionTime)
+        : undefined,
+
+      // TODO: Remove these once virtual instanceConfigFields is supported
+      minScannedSinceISODate: config.minScannedSinceISODate,
+      minFindingsSinceISODate: config.minFindingsSinceISODate,
+    },
     'Configuration values validated, verifying authentication...',
   );
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -484,19 +484,19 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@jupiterone/data-model@^0.14.0":
-  version "0.14.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/data-model/-/data-model-0.14.0.tgz#3105d582ab7ae4796d1100463780f71396818e07"
-  integrity sha512-OLlKJWLcNSf41rydpHTEiKMT+NDBjxaD75VX9e9UyklCojcyXVmY0D9B65N1c0HDylJKBVl6SZ0jkPyow4zJ0Q==
+"@jupiterone/data-model@^0.15.0":
+  version "0.15.1"
+  resolved "https://registry.yarnpkg.com/@jupiterone/data-model/-/data-model-0.15.1.tgz#382fa7d861afb1f298bc06a60bca651193952198"
+  integrity sha512-Vz569gnXoMI9aDVNlUsk8yo858YElnzP6hx606MtYCSvaVRstqAdcKawlhART+z1msnw6A5evw9qLkQQzMoD1A==
   dependencies:
     ajv "^6.12.0"
 
-"@jupiterone/integration-sdk-cli@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-cli/-/integration-sdk-cli-4.0.0.tgz#6681141c97338c836159f93928fa83f0b6f607b4"
-  integrity sha512-/oScZpt3emFLmIOvFWaDy+8GKOm7c36ZVEqDOm0pdCQZD48/5az/t4c5ZlCA9Fe5Dnih0p8DDTasZW3tumSjQw==
+"@jupiterone/integration-sdk-cli@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-cli/-/integration-sdk-cli-4.1.0.tgz#ec0e01acf6a371f5d718c8e33ae691e047329f11"
+  integrity sha512-CBRDCa7RDBBbfvYClWKapWLfPaSlwWllTMyig92maGOs1ehp+1lagUqgGjOV6C8XONplVWIGsFgKxAwYtqB8CA==
   dependencies:
-    "@jupiterone/integration-sdk-runtime" "^4.0.0"
+    "@jupiterone/integration-sdk-runtime" "^4.1.0"
     commander "^5.0.0"
     globby "^11.0.0"
     lodash "^4.17.19"
@@ -504,22 +504,22 @@
     upath "^1.2.0"
     vis "^4.21.0-EOL"
 
-"@jupiterone/integration-sdk-core@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-core/-/integration-sdk-core-4.0.0.tgz#eb34f153d2cd7317516283866520efa56820c233"
-  integrity sha512-n6nKco6dOUfrqUcya/wvaz+NndjNYqEHhkZIHwxdxtZ5A8UzLLZr9f8fP/KMkUXiNahnFxBBYuukx4q+UcnOPQ==
+"@jupiterone/integration-sdk-core@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-core/-/integration-sdk-core-4.1.0.tgz#71e6368cadc8502d99bb665603b2efcb2b2c8eec"
+  integrity sha512-g+zC81WDA7/8ZIiOB5b7eTb1S5L8sbCXBeqwSfsYO9Lh57kKy5JAQ7SR8C/pg4KzRVyq/puANS2WGzYy4/bZIQ==
   dependencies:
-    "@jupiterone/data-model" "^0.14.0"
+    "@jupiterone/data-model" "^0.15.0"
     lodash "^4.17.15"
     uuid "^7.0.3"
 
-"@jupiterone/integration-sdk-dev-tools@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-dev-tools/-/integration-sdk-dev-tools-4.0.0.tgz#99e8bd4f12f563c6adf168366dc0868d821ae497"
-  integrity sha512-wq3EckcWlB0g1fq5JG5MMnq7qlsoR2axAHMukA5VbK2GBbDda6w7T6wYpa8pjgFfxvQoqn8XTH6bLwhgThGmfQ==
+"@jupiterone/integration-sdk-dev-tools@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-dev-tools/-/integration-sdk-dev-tools-4.1.0.tgz#2ab21b3f371f044764139ab5a42d75dec9fadcd7"
+  integrity sha512-g0svTy6INnZODp68gMYWhDa+eCWXPz1mybHioNOOHpRx21tibqlh+xivqsmKhuN6DzvIbmH7A/pX2qLvOVDOfQ==
   dependencies:
-    "@jupiterone/integration-sdk-cli" "^4.0.0"
-    "@jupiterone/integration-sdk-testing" "^4.0.0"
+    "@jupiterone/integration-sdk-cli" "^4.1.0"
+    "@jupiterone/integration-sdk-testing" "^4.1.0"
     "@types/jest" "^25.2.3"
     "@types/node" "^14.0.5"
     "@typescript-eslint/eslint-plugin" "^3.8.0"
@@ -535,12 +535,12 @@
     ts-node "^8.10.2"
     typescript "^3.9.3"
 
-"@jupiterone/integration-sdk-runtime@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-runtime/-/integration-sdk-runtime-4.0.0.tgz#2bef58476b24c6fbc625f84ae6426f65eb45f105"
-  integrity sha512-iadYr13kKuru0Yhbp6H5Ayc4gcp3uEw13WwxlUXBDH87ZDD3B+zV/xNNS2J2xQ22DK3YW2tXdjae46vTf70q2g==
+"@jupiterone/integration-sdk-runtime@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-runtime/-/integration-sdk-runtime-4.1.0.tgz#30dc9b7b6c2ac37140a02326bf8c7badd2294fdb"
+  integrity sha512-/KjmNPTuMpEUNUGlscIDEPk/Z2A9Vy2HawwmMehITJedU57SciK46pKeTzbKgjbJaRKCQf94tJ66m5D5VWgSNQ==
   dependencies:
-    "@jupiterone/integration-sdk-core" "^4.0.0"
+    "@jupiterone/integration-sdk-core" "^4.1.0"
     "@lifeomic/alpha" "^1.1.3"
     async-sema "^3.1.0"
     axios "^0.19.2"
@@ -557,13 +557,13 @@
     rimraf "^3.0.2"
     uuid "^7.0.3"
 
-"@jupiterone/integration-sdk-testing@^4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-testing/-/integration-sdk-testing-4.0.0.tgz#23edeb96b91f3d09533a9d0187b0007b2cc0ac7f"
-  integrity sha512-DGbvmIb/MBIRsJEQeVWjZ9fu1E955ALxLijBQS8nBNZ9MYP7PqexA5fwJM24Z0hIv6EeZt1E9LCJXUf50+ZloA==
+"@jupiterone/integration-sdk-testing@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-testing/-/integration-sdk-testing-4.1.0.tgz#60098bf05088249dd56ccda7c20475b12acbc473"
+  integrity sha512-K8l2r/FN4dJylXa5obb43wCZyIodUVf58nf8Lz3Y2ZX5ekRsMGVXS5vYkejrmY+uWEKOzqTr8XlJ4DqIM/Xb8g==
   dependencies:
-    "@jupiterone/integration-sdk-core" "^4.0.0"
-    "@jupiterone/integration-sdk-runtime" "^4.0.0"
+    "@jupiterone/integration-sdk-core" "^4.1.0"
+    "@jupiterone/integration-sdk-runtime" "^4.1.0"
     "@pollyjs/adapter-node-http" "^4.0.4"
     "@pollyjs/core" "^4.0.4"
     "@pollyjs/persister-fs" "^4.0.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -491,12 +491,12 @@
   dependencies:
     ajv "^6.12.0"
 
-"@jupiterone/integration-sdk-cli@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-cli/-/integration-sdk-cli-4.1.0.tgz#ec0e01acf6a371f5d718c8e33ae691e047329f11"
-  integrity sha512-CBRDCa7RDBBbfvYClWKapWLfPaSlwWllTMyig92maGOs1ehp+1lagUqgGjOV6C8XONplVWIGsFgKxAwYtqB8CA==
+"@jupiterone/integration-sdk-cli@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-cli/-/integration-sdk-cli-4.2.0.tgz#6958862329ed492ac684d122e8853fff87c2cef4"
+  integrity sha512-T17XMWiYedYj24JfhrWLcAh+TbEjCiKaMwivokRLyxZJVho1tU/qczUHfjY/uFIk40IkvwAEKssfEl40qRPr9w==
   dependencies:
-    "@jupiterone/integration-sdk-runtime" "^4.1.0"
+    "@jupiterone/integration-sdk-runtime" "^4.2.0"
     commander "^5.0.0"
     globby "^11.0.0"
     lodash "^4.17.19"
@@ -504,22 +504,22 @@
     upath "^1.2.0"
     vis "^4.21.0-EOL"
 
-"@jupiterone/integration-sdk-core@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-core/-/integration-sdk-core-4.1.0.tgz#71e6368cadc8502d99bb665603b2efcb2b2c8eec"
-  integrity sha512-g+zC81WDA7/8ZIiOB5b7eTb1S5L8sbCXBeqwSfsYO9Lh57kKy5JAQ7SR8C/pg4KzRVyq/puANS2WGzYy4/bZIQ==
+"@jupiterone/integration-sdk-core@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-core/-/integration-sdk-core-4.2.0.tgz#a90bd37b14530e2da373c8fc4d9c0b660e0cf274"
+  integrity sha512-5p91KagldvdMgmHcYBpLRO4sl3BasM/SuwwioDAJFo+F0G/WdkZaJuKTqU6bZpQf+vsTPXFe/HHk1JZ1SOJU0A==
   dependencies:
     "@jupiterone/data-model" "^0.15.0"
     lodash "^4.17.15"
     uuid "^7.0.3"
 
-"@jupiterone/integration-sdk-dev-tools@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-dev-tools/-/integration-sdk-dev-tools-4.1.0.tgz#2ab21b3f371f044764139ab5a42d75dec9fadcd7"
-  integrity sha512-g0svTy6INnZODp68gMYWhDa+eCWXPz1mybHioNOOHpRx21tibqlh+xivqsmKhuN6DzvIbmH7A/pX2qLvOVDOfQ==
+"@jupiterone/integration-sdk-dev-tools@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-dev-tools/-/integration-sdk-dev-tools-4.2.0.tgz#ab5591c2289ffd0df6021e2b411ba4ef30b8e5e4"
+  integrity sha512-0IUgj7yAQbITS/hmB24Rot+I4Pu8alfbeRLfqqCKjGxRsuf1OdcicgEM+pvrBtbnhhRvpvlzJ40e+QHK/GQ2IA==
   dependencies:
-    "@jupiterone/integration-sdk-cli" "^4.1.0"
-    "@jupiterone/integration-sdk-testing" "^4.1.0"
+    "@jupiterone/integration-sdk-cli" "^4.2.0"
+    "@jupiterone/integration-sdk-testing" "^4.2.0"
     "@types/jest" "^25.2.3"
     "@types/node" "^14.0.5"
     "@typescript-eslint/eslint-plugin" "^3.8.0"
@@ -535,12 +535,12 @@
     ts-node "^8.10.2"
     typescript "^3.9.3"
 
-"@jupiterone/integration-sdk-runtime@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-runtime/-/integration-sdk-runtime-4.1.0.tgz#30dc9b7b6c2ac37140a02326bf8c7badd2294fdb"
-  integrity sha512-/KjmNPTuMpEUNUGlscIDEPk/Z2A9Vy2HawwmMehITJedU57SciK46pKeTzbKgjbJaRKCQf94tJ66m5D5VWgSNQ==
+"@jupiterone/integration-sdk-runtime@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-runtime/-/integration-sdk-runtime-4.2.0.tgz#fc06d8471e20de533ea60414fd66d5f396e899de"
+  integrity sha512-hwTR4jiRyXDD6cBy+/9b1KKxxPhG9z+qhbqUmBOat5ZyceV7QZlcI7f2zz9c1FqhNfA81XlZoMS0Tan3yZQ4Pg==
   dependencies:
-    "@jupiterone/integration-sdk-core" "^4.1.0"
+    "@jupiterone/integration-sdk-core" "^4.2.0"
     "@lifeomic/alpha" "^1.1.3"
     async-sema "^3.1.0"
     axios "^0.19.2"
@@ -557,13 +557,13 @@
     rimraf "^3.0.2"
     uuid "^7.0.3"
 
-"@jupiterone/integration-sdk-testing@^4.1.0":
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-testing/-/integration-sdk-testing-4.1.0.tgz#60098bf05088249dd56ccda7c20475b12acbc473"
-  integrity sha512-K8l2r/FN4dJylXa5obb43wCZyIodUVf58nf8Lz3Y2ZX5ekRsMGVXS5vYkejrmY+uWEKOzqTr8XlJ4DqIM/Xb8g==
+"@jupiterone/integration-sdk-testing@^4.2.0":
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/@jupiterone/integration-sdk-testing/-/integration-sdk-testing-4.2.0.tgz#cba24381fbcae804878f2456dc514cfd765d472f"
+  integrity sha512-OBxwYDUKrHJqrJLIMN95NYuYJR8D7ZcFZHz988H77cyFrRxPYUGnn2BAc+0/tpF6yj/2V6m0Mp2aiUpVpHpmMg==
   dependencies:
-    "@jupiterone/integration-sdk-core" "^4.1.0"
-    "@jupiterone/integration-sdk-runtime" "^4.1.0"
+    "@jupiterone/integration-sdk-core" "^4.2.0"
+    "@jupiterone/integration-sdk-runtime" "^4.2.0"
     "@pollyjs/adapter-node-http" "^4.0.4"
     "@pollyjs/core" "^4.0.4"
     "@pollyjs/persister-fs" "^4.0.4"


### PR DESCRIPTION
When execution history is available, the start time of the last successful execution will be used to fetch findings modified since that time. This is meant to perform a rolling ingestion of data. The changes use an additional change in the integration SDK that allows for declaring that a type of data will never be a complete set, so that the persister will not delete any of that type of data.

This is safe to execute against integration configurations that have never executed, as well as older configurations that do not have `*DaysSince` values. We should be able to version as `4.5.0`. Receiving the history will depend on releasing [changes to jupiter-managed-integration](https://bitbucket.org/jupiterone/jupiter-managed-integration/pull-requests/67).