### PR TITLE
Fix detections concurrency calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,16 @@
 
 ## [Unreleased]
 
+## 5.0.3 - 2020-01-04
+
+### Fixed
+
+- Detections request concurrency incorrectly calculated, reducing number of
+  active requests
+
 ## 5.0.2 - 2020-01-03
 
-## Changed
+### Changed
 
 - Mock Qualys server data generator may be configured to emit exact numbers of
   hosts and total detections across all hosts
@@ -18,14 +25,14 @@
   When `typeof QID !== 'number'`, the detection will be skipped and the number
   of times this occurrs is logged.
 
-## Fixed
+### Fixed
 
 - Mock Qualys server host IDs endpoint answered invalid host ID values, leading
   to a failure to list detections
 
-# 5.0.1 - 2020-01-02
+## 5.0.1 - 2020-01-02
 
-## Changed
+### Changed
 
 - Upgrade `@jupiterone/integration-sdk-\*@5.5.0`
 - Removed empty raw data from Finding entities to avoid unecessary use of space
@@ -49,7 +56,7 @@
   instances
 - Disable Service - IDENTIFIED -> Finding relationships temporarily
 
-## Fixed
+### Fixed
 
 - Duplicate values in `Finding.targets` are removed
 - Memory leak in SDK impacting long running instances
@@ -70,7 +77,7 @@
 - Request details for more hosts per request, submit more requests concurrently
   to reduce total time to fetch large numbers of hosts.
 
-## Added
+### Added
 
 - `yarn start:qualys` provides a mock implementation of some of the Qualys APIs
   used by the integration.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-qualys",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "description": "Qualys integration for JupiterOne",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/provider/client/util.test.ts
+++ b/src/provider/client/util.test.ts
@@ -15,20 +15,47 @@ describe('calculateConcurrency', () => {
   }
 
   test.each([
-    [0, 0, 1],
-    [1, 0, 1],
-    [1, 1, 1],
-    [2, 0, 1],
-    [2, 1, 1],
-    [2, 2, 1],
-    [15, 0, 11],
-    [15, 5, 7],
-    [15, 9, 4],
+    // Always allow at least one request.
+    [0, 0, 0, 1],
+    [1, 0, 0, 1],
+    [0, 1, 0, 1],
+    [0, 1, 1, 1],
+    [1, 1, 1, 1],
+    [0, 2, 0, 1],
+    [1, 2, 0, 1],
+    [0, 2, 1, 1],
+    [1, 2, 1, 1],
+    [0, 2, 2, 1],
+    [1, 2, 2, 1],
+
+    // Use %75 of total to leave some for other scripts.
+    [0, 15, 0, 11],
+
+    // Handle case where it looks like another script is busy with the
+    // connections, don't take more than ~75% of what's left to leave room for
+    // other scripts.
+    [0, 15, 5, 7],
+    [0, 15, 9, 4],
+
+    // Assume this script is the one that is active, so allow it more room.
+    [5, 15, 5, 11],
+
+    // Others appear to be active while this one is, but there isn't any reason
+    // to avoid allowing more.
+    [4, 15, 9, 11],
+
+    // Handle cases where we consider ourselves active, but the server has
+    // completed one or all responses.
+    [5, 15, 0, 11],
+    [11, 15, 2, 11],
   ])(
-    'concurrency: %s, running: %s',
-    (concurrency, concurrencyRunning, expected) => {
+    'active: %s, concurrency: %s, running: %s',
+    (active, concurrency, concurrencyRunning, expected) => {
       expect(
-        calculateConcurrency(state({ concurrency, concurrencyRunning })),
+        calculateConcurrency(
+          active,
+          state({ concurrency, concurrencyRunning }),
+        ),
       ).toEqual(expected);
     },
   );

--- a/src/steps/vulns/index.ts
+++ b/src/steps/vulns/index.ts
@@ -35,6 +35,10 @@ import {
  * we don't have to re-load the vuln CVE data. Do not store everything, only
  * that necessary for CVE info.
  *
+ * TODO: Consider a FindingUploaderThingy that has a cache/fetches Vulns at
+ * threshold, then patches Findings with some vuln details and then adds to
+ * jobState.
+ *
  * @see `createVulnerabilityTargetEntities`
  */
 export async function fetchFindingVulnerabilities({
@@ -58,6 +62,9 @@ export async function fetchFindingVulnerabilities({
     const vulnFindingKeys = vulnerabilityFindingKeysMap.get(vuln.QID!);
     if (vulnFindingKeys) {
       for (const findingKey of vulnFindingKeys) {
+        // TODO: don't use findEntity, we don't have them, and we don't need to
+        // prove that it exists; we could use jobState.hasKey() if we want to
+        // avoid bad relationships
         const findingEntity = await jobState.findEntity(findingKey);
         if (!findingEntity) {
           logger.warn(


### PR DESCRIPTION
Testing with:
- 100,000 hosts total
- 1000 hosts per request
- 100 total requests
- Logging concurrent connections in mock server

Old vs new implementation shows that we get more active concurrency:
```js
[1,1,2,3,4,5,6,7,8,9,10,9,7,8,9,2,3,3,4,5,6,7,8,9,9,8,6,6,7,8,5,6,7,4,5,6,6,7,6,3,4,5,6,6,6,7,8,6,6,6,6,7,8,9,2,3,4,5,6,6,7,6,7,8,9,4,5,5,4,5,6,6,7,6,3,4,5,6,7,8,7,6,5,6,7,6,6,5,5,6,6,7,6,7,6,6,6,7,2,3]
[1,1,2,3,4,5,6,7,8,9,10,11,10,11,9,9,10,11,9,10,11,10,9,7,8,9,10,11,6,7,8,9,10,11,9,10,11,10,11,11,10,11,11,9,9,10,10,9,8,9,10,10,10,6,7,8,9,10,11,11,7,7,8,9,10,11,11,8,8,9,3,4,5,6,7,8,9,10,10,11,10,8,7,5,6,7,8,9,10,11,9,9,9,10,10,11,4,5,6,7]
```