### PR TITLE
Disable showing host detections results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## [Unreleased]
 
+## 5.0.4 - 2020-01-05
+
 ### Added
 
 - Mock Qualys server prevents exceeding detections endpoint concurrency limit,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Mock Qualys server allows simulating additional number of concurrent requests
   that belong to other scripts, to assist testing concurrency code
 
+### Changed
+
+- Disable receiving the `RESULTS` field from the Qualys host detections response
+
 ### Fixed
 
 - Fixed bug in concurrency calculation that allowed too many active requests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-qualys",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "description": "Qualys integration for JupiterOne",
   "license": "MPL-2.0",
   "main": "dist/index.js",

--- a/src/provider/client/index.ts
+++ b/src/provider/client/index.ts
@@ -667,6 +667,7 @@ export class QualysAPIClient {
         action: 'list',
         show_tags: '1',
         show_igs: '1',
+        show_results: '0',
         output_format: 'XML',
         truncation_limit: String(ids.length),
         ids: ids.map(String),


### PR DESCRIPTION
This change significantly reduces the size of the Qualys HTTP response for the host detections endpoint. In some cases the results were > 300mb and we have to parse the XML response as JSON. This should help reduce memory, CPU, and speed up the host detections processing.