### PR TITLE
Use concurrency code when fetching vulns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Fetching knowledge base vulnerabilities using concurrency headers from Qualys
+  server responses
+
 ## 5.0.4 - 2020-01-05
 
 ### Added

--- a/src/provider/client.test.ts
+++ b/src/provider/client.test.ts
@@ -1341,9 +1341,13 @@ describe('iterateVulnerabilities', () => {
 
     const vulns: vmpc.Vuln[] = [];
 
-    await createClient().iterateVulnerabilities([], (vuln) => {
-      vulns.push(vuln);
-    });
+    await createClient().iterateVulnerabilities(
+      [],
+      (vuln) => {
+        vulns.push(vuln);
+      },
+      { onRequestError: jest.fn() },
+    );
 
     expect(vulns.length).toBe(0);
   });
@@ -1357,9 +1361,13 @@ describe('iterateVulnerabilities', () => {
 
     const vulns: vmpc.Vuln[] = [];
 
-    await createClient().iterateVulnerabilities([123], (vuln) => {
-      vulns.push(vuln);
-    });
+    await createClient().iterateVulnerabilities(
+      [123],
+      (vuln) => {
+        vulns.push(vuln);
+      },
+      { onRequestError: jest.fn() },
+    );
 
     expect(vulns.length).toBe(0);
   });
@@ -1371,14 +1379,25 @@ describe('iterateVulnerabilities', () => {
       options: { recordFailedRequests: true },
     });
 
-    await expect(
-      createClient().iterateVulnerabilities(
-        [('abc123' as unknown) as number],
-        async (_) => {
-          // noop
-        },
-      ),
-    ).rejects.toThrow(/Bad Request/);
+    const onRequestError = jest.fn();
+
+    await createClient().iterateVulnerabilities(
+      [('abc123' as unknown) as number],
+      async (_) => {
+        // noop
+      },
+      {
+        onRequestError,
+      },
+    );
+
+    expect(onRequestError).toHaveBeenCalledTimes(1);
+    expect(onRequestError).toHaveBeenCalledWith(
+      ['abc123'],
+      expect.objectContaining({
+        message: expect.stringMatching(/Bad Request/),
+      }),
+    );
   });
 
   test('some', async () => {
@@ -1390,9 +1409,13 @@ describe('iterateVulnerabilities', () => {
     const client = createClient();
     const vulns: vmpc.Vuln[] = [];
 
-    await client.iterateVulnerabilities([316760], (vuln) => {
-      vulns.push(vuln);
-    });
+    await client.iterateVulnerabilities(
+      [316760],
+      (vuln) => {
+        vulns.push(vuln);
+      },
+      { onRequestError: jest.fn() },
+    );
 
     expect(vulns.length).toBe(1);
   });

--- a/src/steps/vulns/converters.ts
+++ b/src/steps/vulns/converters.ts
@@ -1,6 +1,5 @@
 import {
   createMappedRelationship,
-  Entity,
   generateRelationshipType,
   MappedRelationship,
   RelationshipClass,
@@ -10,6 +9,7 @@ import {
 
 import { vmpc } from '../../provider/client';
 import toArray from '../../util/toArray';
+import { ENTITY_TYPE_HOST_FINDING } from '../vmdr/constants';
 import {
   ENTITY_TYPE_CVE_VULNERABILITY,
   ENTITY_TYPE_QUALYS_VULNERABILITY,
@@ -24,7 +24,7 @@ import {
  * representing each vulnerability associated with the Finding
  */
 export function createFindingVulnerabilityMappedRelationships(
-  findingEntity: Entity,
+  findingKey: string,
   targetEntityProperties: TargetEntityProperties[],
 ): { relationships: MappedRelationship[]; duplicates: MappedRelationship[] } {
   const seenRelationshipKeys = new Set<string>();
@@ -36,12 +36,12 @@ export function createFindingVulnerabilityMappedRelationships(
       _class: RelationshipClass.IS,
       _type: generateRelationshipType(
         RelationshipClass.IS,
-        findingEntity._type,
+        ENTITY_TYPE_HOST_FINDING,
         targetEntity._type!,
       ),
       _mapping: {
         relationshipDirection: RelationshipDirection.FORWARD,
-        sourceEntityKey: findingEntity._key,
+        sourceEntityKey: findingKey,
         targetFilterKeys: [['_type', '_key']],
         targetEntity,
       },


### PR DESCRIPTION
Fetching is not yet enabled to keep the PRs focused. Note that this includes fixes for counting in the detections fetching code as well.