### PR TITLE
Fix Service SCANS Host qualysAssetId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Changed
+
+- Removed `discovered_host.qualysHostId`. The value is now stored in
+  `discovered_host.qualysAssetId`.
+
+### Fixed
+
+- Fixed a failure to properly map `Service - SCANS -> Host` relationships. The
+  mapping target entity value for `discovered_host.qualysAssetId` needs to match
+  the `Finding.hostId` so that `Service - SCANS -> Host` and
+  `Finding <- HAS - Host` relationships connect to the same `Host` entities. See
+  `src/provider/client/types/index.ts` for details on the distinctions between
+  Qualys host IDs.
+
 ## [5.8.9] - 2021-10-28
 
 ### Changed

--- a/src/provider/client/types/assets.ts
+++ b/src/provider/client/types/assets.ts
@@ -1,3 +1,4 @@
+import { AssetHostId } from '../';
 import { QWebHostId } from './index';
 import { ServiceResponseBody } from './qps';
 import { ISODateString, PossibleArray } from './util';
@@ -12,7 +13,7 @@ export type Data = {
 };
 
 export type HostAsset = {
-  id?: number;
+  id?: AssetHostId;
   name?: string;
   created?: ISODateString;
   modified?: ISODateString;

--- a/src/provider/client/types/index.ts
+++ b/src/provider/client/types/index.ts
@@ -8,9 +8,37 @@ export * from './client';
 export * from './util';
 
 /**
- * VMDR module "QWEB" host IDs.
+ * Host ID tracking in VMDR module ("QWEB").
  *
  * @see https://qualys-secure.force.com/discussions/s/article/000006216 to
- * understand the difference between the three types of IDs in Qualys.
+ * understand the difference between the four types of IDs in Qualys.
  */
 export type QWebHostId = number;
+
+/**
+ * Host ID tracking in products other than VM or PC.
+ *
+ * @see https://qualys-secure.force.com/discussions/s/article/000006216 to
+ * understand the difference between the four types of IDs in Qualys.
+ */
+export type AssetHostId = number;
+
+/**
+ * Host ID GUID
+ *
+ * > There is also the similarly named but quite different Qualys Host ID. This is
+ * > sometimes referred to as the QG Host ID or Agentless Tracking GUID.  This is
+ * > a GUID format ID found on assets that have either the Cloud Agent installed
+ * > or have been scanned with an authenticated scan and Agentless Tracking
+ * > enabled. Note the difference, the Qualys Host ID GUID represents hosts, and
+ * > there will be a maximum of one Qualys Host ID for any host in the network,
+ * > regardless of the number of interfaces it has. The Host ID discussed above
+ * > represents scanned assets, so a single host with 5 scanned interfaces will be
+ * > represented by five entries in the Qualys asset database, each with a unique
+ * > ID, but only one Qualys Host ID if and only if it has an Agent or has been
+ * > scanned with authentication and Agentless Tracking enabled.
+ *
+ * @see https://qualys-secure.force.com/discussions/s/article/000006216 to
+ * understand the difference between the four types of IDs in Qualys.
+ */
+export type QGHostId = string;

--- a/src/provider/client/types/vmpc/listHostDetections.ts
+++ b/src/provider/client/types/vmpc/listHostDetections.ts
@@ -1,5 +1,5 @@
 import { QualyNumericSeverity } from '../../../../types';
-import { QWebHostId } from '../index';
+import { QGHostId, QWebHostId } from '../index';
 import { ISODateString, PossibleArray } from '../util';
 
 // https://www.qualys.com/docs/qualys-api-vmpc-user-guide.pdf
@@ -49,7 +49,7 @@ export type DetectionHost = {
   LAST_VM_SCANNED_DURATION?: number;
   DETECTION_LIST?: HostDetectionList;
   NETBIOS?: string;
-  QG_HOSTID?: string;
+  QG_HOSTID?: QGHostId;
   LAST_VM_AUTH_SCANNED_DATE?: ISODateString;
   LAST_PC_SCANNED_DATE?: ISODateString;
 };

--- a/src/steps/vmdr/converters.test.ts
+++ b/src/steps/vmdr/converters.test.ts
@@ -57,7 +57,6 @@ describe('createDiscoveredHostAssetTargetEntity', () => {
           properties: {
             _type: { const: 'discovered_host' },
             qualysAssetId: { type: 'number' },
-            qualysHostId: { type: 'number' },
             qualysCreatedOn: { type: 'number' },
 
             scannedBy: { type: 'string' },
@@ -81,7 +80,6 @@ describe('createDiscoveredHostAssetTargetEntity', () => {
           'os',
           'platform',
           'qualysAssetId',
-          'qualysHostId',
           'qualysCreatedOn',
           'scannedBy',
           'lastScannedOn',

--- a/src/steps/vmdr/converters.ts
+++ b/src/steps/vmdr/converters.ts
@@ -385,8 +385,8 @@ export function getHostAssetDetails(host: assets.HostAsset) {
     os,
     platform,
 
-    qualysAssetId: host.id, // Used as target filter for Service|Finding -> Host
-    qualysHostId: host.qwebHostId,
+    qualysAssetId: host.qwebHostId, // Used as target filter for Service|Finding -> Host
+
     qualysCreatedOn: parseTimePropertyValue(host.created),
 
     scannedBy: 'qualys',


### PR DESCRIPTION
* The `Finding` hot path is currently not finding existing `discovered_host` entities that are related to `Service` entities, because the `Service - SCANS -> Host` mapped relationship creates `discovered_host` entities with incorrect values in `qualysAssetId`. Conversely, the `Service - SCANS -> Host` mapped relationships do not find those `discovered_host` entities created by the hot path.
* New `discovered_host` entities will not have the `qualysHostId`. I think we should use this fact - that there are `discovered_host` entities _with_ `qualysHostId` related to `Service` - and possibly also that they are not related to `Finding` entities (need to verify) to script the deletion of those `discovered_host` entities.
