### PR TITLE
Fix _key in Service SCANS Host target entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   support this change, the Vulnerability step now runs in separate dependency
   graph that runs after all other steps.
 
+- Fixed discrepency in how `discovered_host._key` is generated to match the
+  value produced by the `Finding <- HAS - discovered_host` relationship
+  processing.
+
 ## [5.8.8] - 2021-10-19
 
 ### Changed

--- a/src/steps/vmdr/converters.ts
+++ b/src/steps/vmdr/converters.ts
@@ -397,8 +397,19 @@ export function getHostAssetDetails(host: assets.HostAsset) {
   };
 }
 
+/**
+ * Generates a _key value for a host asset.
+ *
+ * This does not consider the POD the integration is ingesting data from, which
+ * may become important if a customer ingests data from two Qualys subscriptions
+ * that are not in the same POD. The ID documentation tells us the values can be
+ * the same for two different hosts from two PODS because the values are no
+ * globally unique.
+ *
+ * @see https://success.qualys.com/discussions/s/article/000006216
+ */
 function generateHostAssetKey(host: assets.HostAsset): string {
-  return `qualys-host:${host.qwebHostId!}`;
+  return `Host:${host.qwebHostId!}`;
 }
 
 function getHostAssetIPAddresses(host: assets.HostAsset) {


### PR DESCRIPTION
These changes likely should be released alongside #152 so that going forward when entities are created by the `Service - SCANS -> discovered_host` they will have a `_key` value that matches the `Finding` hot path-created entities.